### PR TITLE
MCP-49 Enable Develocity remote cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,8 @@ env:
   ARTIFACTORY_URL: VAULT[development/kv/data/repox data.url]
   ARTIFACTORY_PRIVATE_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader
   ARTIFACTORY_PRIVATE_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
+  DEVELOCITY_TOKEN: VAULT[development/kv/data/develocity data.token]
+  DEVELOCITY_ACCESS_KEY: develocity.sonar.build=${DEVELOCITY_TOKEN}
   SLACK_TOKEN: VAULT[development/kv/data/slack data.token]
   SLACK_CHANNEL: squad-ide-mcp-server-bots
   GRADLE_VERSION: "8.13"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,9 @@ buildCache {
 develocity {
     server = "https://develocity.sonar.build"
     buildScan {
-        publishing.onlyIf { false }
+        publishing.onlyIf { isCiServer && it.isAuthenticated }
+        capture {
+            buildLogging.set(!startParameter.taskNames.contains("properties"))
+        }
     }
 }


### PR DESCRIPTION
[MCP-49](https://sonarsource.atlassian.net/browse/MCP-49)



[MCP-49]: https://sonarsource.atlassian.net/browse/MCP-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ