### PR TITLE
MCP-59 Use the v5 alias for the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@34d8b20d125bfd58d124e84b007d3a18e61c358a # 5.10.4
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       slackChannel: squad-ide-mcp-server-bots


### PR DESCRIPTION
[MCP-59](https://sonarsource.atlassian.net/browse/MCP-59)

We will automatically benefit from updates

[MCP-59]: https://sonarsource.atlassian.net/browse/MCP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ