### PR TITLE
MCP-76 Pagination should correctly be handled

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
@@ -65,8 +65,9 @@ public class SearchIssuesTool extends Tool {
     stringBuilder.append("Found ").append(issues.size()).append(" issues.\n");
 
     var paging = response.paging();
+    var totalPages = (int) Math.ceil((double) paging.total() / paging.pageSize());
     stringBuilder.append("This response is paginated and this is the page ").append(paging.pageIndex())
-      .append(" out of ").append(paging.total()).append(" total pages. There is a maximum of ")
+      .append(" out of ").append(totalPages).append(" total pages. There is a maximum of ")
       .append(paging.pageSize()).append(" issues per page.\n");
 
     for (var issue : issues) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsTool.java
@@ -54,9 +54,12 @@ public class SearchMyProjectsTool extends Tool {
     }
 
     stringBuilder.append("Found ").append(projects.size()).append(" Sonar projects in your organization.\n");
-    stringBuilder.append("This response is paginated and this is the page ").append(response.paging().pageIndex())
-      .append(" out of ").append(response.paging().total()).append(" total pages. There is a maximum of ")
-      .append(response.paging().pageSize()).append(" projects per page.\n");
+    
+    var paging = response.paging();
+    var totalPages = (int) Math.ceil((double) paging.total() / paging.pageSize());
+    stringBuilder.append("This response is paginated and this is the page ").append(paging.pageIndex())
+      .append(" out of ").append(totalPages).append(" total pages. There is a maximum of ")
+      .append(paging.pageSize()).append(" projects per page.\n");
 
     projects.forEach(p -> {
       stringBuilder.append("Project key: ").append(p.key()).append(" | Project name: ").append(p.name());

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
@@ -99,7 +99,7 @@ class SearchIssuesToolTests {
                 "paging": {
                   "pageIndex": 2,
                   "pageSize": 100,
-                  "total": 3
+                  "total": 200
                 },
                 "issues": [%s],
                 "components": [],
@@ -119,7 +119,7 @@ class SearchIssuesToolTests {
       assertThat(result)
         .isEqualTo(new McpSchema.CallToolResult("""
           Found 1 issues.
-          This response is paginated and this is the page 2 out of 3 total pages. There is a maximum of 100 issues per page.
+          This response is paginated and this is the page 2 out of 2 total pages. There is a maximum of 100 issues per page.
           Issue key: %s | Rule: %s | Project: %s | Component: com.github.kevinsawicki:http-request:com.github.kevinsawicki.http.HttpRequest | Severity: MINOR | Status: RESOLVED | Message: '3' is a magic number. | Attribute: CLEAR | Category: INTENTIONAL | Author: Developer 1 | Start Line: 2 | End Line: 2 | Created: 2013-05-13T17:55:39+0200
           """.formatted(issueKey, ruleName, projectName).trim(), false));
       assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
@@ -138,7 +138,7 @@ class SearchIssuesToolTests {
                 "paging": {
                   "pageIndex": 1,
                   "pageSize": 100,
-                  "total": 2
+                  "total": 200
                 },
                 "issues": [%s],
                 "components": [],
@@ -214,7 +214,7 @@ class SearchIssuesToolTests {
                 "paging": {
                   "pageIndex": 2,
                   "pageSize": 50,
-                  "total": 3
+                  "total": 175
                 },
                 "issues": [%s],
                 "components": [],
@@ -236,7 +236,7 @@ class SearchIssuesToolTests {
       assertThat(result)
         .isEqualTo(new McpSchema.CallToolResult("""
           Found 1 issues.
-          This response is paginated and this is the page 2 out of 3 total pages. There is a maximum of 50 issues per page.
+          This response is paginated and this is the page 2 out of 4 total pages. There is a maximum of 50 issues per page.
           Issue key: %s | Rule: %s | Project: %s | Component: com.github.kevinsawicki:http-request:com.github.kevinsawicki.http.HttpRequest | Severity: MINOR | Status: RESOLVED | Message: '3' is a magic number. | Attribute: CLEAR | Category: INTENTIONAL | Author: Developer 1 | Start Line: 2 | End Line: 2 | Created: 2013-05-13T17:55:39+0200
           """.formatted(issueKey, ruleName, projectName).trim(), false));
       assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
@@ -360,7 +360,7 @@ class SearchIssuesToolTests {
                 "paging": {
                   "pageIndex": 2,
                   "pageSize": 100,
-                  "total": 3
+                  "total": 200
                 },
                 "issues": [%s],
                 "components": [],
@@ -380,7 +380,7 @@ class SearchIssuesToolTests {
       assertThat(result)
         .isEqualTo(new McpSchema.CallToolResult("""
           Found 1 issues.
-          This response is paginated and this is the page 2 out of 3 total pages. There is a maximum of 100 issues per page.
+          This response is paginated and this is the page 2 out of 2 total pages. There is a maximum of 100 issues per page.
           Issue key: %s | Rule: %s | Project: %s | Component: com.github.kevinsawicki:http-request:com.github.kevinsawicki.http.HttpRequest | Severity: MINOR | Status: RESOLVED | Message: '3' is a magic number. | Attribute: CLEAR | Category: INTENTIONAL | Author: Developer 1 | Start Line: 2 | End Line: 2 | Created: 2013-05-13T17:55:39+0200
           """.formatted(issueKey, ruleName, projectName).trim(), false));
       assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
@@ -399,7 +399,7 @@ class SearchIssuesToolTests {
                 "paging": {
                   "pageIndex": 1,
                   "pageSize": 100,
-                  "total": 2
+                  "total": 200
                 },
                 "issues": [%s],
                 "components": [],
@@ -473,7 +473,7 @@ class SearchIssuesToolTests {
                 "paging": {
                   "pageIndex": 2,
                   "pageSize": 50,
-                  "total": 3
+                  "total": 200
                 },
                 "issues": [%s],
                 "components": [],
@@ -493,7 +493,7 @@ class SearchIssuesToolTests {
       assertThat(result)
         .isEqualTo(new McpSchema.CallToolResult("""
           Found 1 issues.
-          This response is paginated and this is the page 2 out of 3 total pages. There is a maximum of 50 issues per page.
+          This response is paginated and this is the page 2 out of 4 total pages. There is a maximum of 50 issues per page.
           Issue key: %s | Rule: %s | Project: %s | Component: com.github.kevinsawicki:http-request:com.github.kevinsawicki.http.HttpRequest | Severity: MINOR | Status: RESOLVED | Message: '3' is a magic number. | Attribute: CLEAR | Category: INTENTIONAL | Author: Developer 1 | Start Line: 2 | End Line: 2 | Created: 2013-05-13T17:55:39+0200
           """.formatted(issueKey, ruleName, projectName).trim(), false));
       assertThat(harness.getMockSonarQubeServer().getReceivedRequests())

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsToolTests.java
@@ -67,7 +67,7 @@ class SearchMyProjectsToolTests {
       var projectName = "Project Name";
       harness.getMockSonarQubeServer().stubFor(get(ComponentsApi.COMPONENTS_SEARCH_PATH + "?p=1&organization=org")
         .willReturn(aResponse().withResponseBody(
-          Body.fromJsonBytes(generateResponse(projectKey, projectName, 1, 4).getBytes(StandardCharsets.UTF_8)))));
+          Body.fromJsonBytes(generateResponse(projectKey, projectName, 1, 400).getBytes(StandardCharsets.UTF_8)))));
       var mcpClient = harness.newClient(Map.of(
         "SONARQUBE_ORG", "org"));
 
@@ -87,7 +87,7 @@ class SearchMyProjectsToolTests {
       var projectName = "Project Name";
       harness.getMockSonarQubeServer().stubFor(get(ComponentsApi.COMPONENTS_SEARCH_PATH + "?p=2&organization=org")
         .willReturn(aResponse().withResponseBody(
-          Body.fromJsonBytes(generateResponse(projectKey, projectName, 2, 2).getBytes(StandardCharsets.UTF_8)))));
+          Body.fromJsonBytes(generateResponse(projectKey, projectName, 2, 200).getBytes(StandardCharsets.UTF_8)))));
       var mcpClient = harness.newClient(Map.of(
         "SONARQUBE_ORG", "org"));
 
@@ -124,7 +124,7 @@ class SearchMyProjectsToolTests {
       var projectName = "Project Name";
       harness.getMockSonarQubeServer().stubFor(get(ComponentsApi.COMPONENTS_SEARCH_PATH + "?p=1&qualifiers=TRK")
         .willReturn(aResponse().withResponseBody(
-          Body.fromJsonBytes(generateResponse(projectKey, projectName, 1, 4).getBytes(StandardCharsets.UTF_8)))));
+          Body.fromJsonBytes(generateResponse(projectKey, projectName, 1, 400).getBytes(StandardCharsets.UTF_8)))));
       var mcpClient = harness.newClient();
 
       var result = mcpClient.callTool(SearchMyProjectsTool.TOOL_NAME);
@@ -143,7 +143,7 @@ class SearchMyProjectsToolTests {
       var projectName = "Project Name";
       harness.getMockSonarQubeServer().stubFor(get(ComponentsApi.COMPONENTS_SEARCH_PATH + "?p=2&qualifiers=TRK")
         .willReturn(aResponse().withResponseBody(
-          Body.fromJsonBytes(generateResponse(projectKey, projectName, 2, 2).getBytes(StandardCharsets.UTF_8)))));
+          Body.fromJsonBytes(generateResponse(projectKey, projectName, 2, 200).getBytes(StandardCharsets.UTF_8)))));
       var mcpClient = harness.newClient();
 
       var result = mcpClient.callTool(
@@ -159,7 +159,7 @@ class SearchMyProjectsToolTests {
     }
   }
 
-  private static String generateResponse(String projectKey, String projectName, int pageIndex, int totalPages) {
+  private static String generateResponse(String projectKey, String projectName, int pageIndex, int totalItems) {
     return """
       {
          "paging": {
@@ -177,7 +177,7 @@ class SearchMyProjectsToolTests {
            }
          ]
        }
-      """.formatted(pageIndex, totalPages, projectKey, projectName);
+      """.formatted(pageIndex, totalItems, projectKey, projectName);
   }
 
 }


### PR DESCRIPTION
Fixing pagination for `search_my_sonarqube_projects` & `search_sonar_issues_in_projects` - thanks @FraserKillip ([PR](https://github.com/SonarSource/sonarqube-mcp-server/pull/65))