### PR TITLE
fix(get_scm_info): cast error with commits_by_line param

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetScmInfoTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetScmInfoTool.java
@@ -36,7 +36,7 @@ public class GetScmInfoTool extends Tool {
       .setName(TOOL_NAME)
       .setDescription("Get SCM information of SonarQube source files. Require See Source Code permission on file's project")
       .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.php)")
-      .addBooleanProperty(COMMITS_BY_LINE_PROPERTY, "Group lines by SCM commit if value is false, else display commits for each line (true/false)")
+      .addStringProperty(COMMITS_BY_LINE_PROPERTY, "Group lines by SCM commit if \"false\", else display commits for each line if \"true\"")
       .addNumberProperty(FROM_PROPERTY, "First line to return. Starts at 1")
       .addNumberProperty(TO_PROPERTY, "Last line to return (inclusive)")
       .build());
@@ -46,7 +46,11 @@ public class GetScmInfoTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
-    var commitsByLine = arguments.getOptionalBoolean(COMMITS_BY_LINE_PROPERTY);
+    var commitsByLineStr = arguments.getOptionalString(COMMITS_BY_LINE_PROPERTY);
+    Boolean commitsByLine = null;
+    if (commitsByLineStr != null) {
+  commitsByLine = Boolean.parseBoolean(commitsByLineStr);
+}
     var from = arguments.getOptionalInteger(FROM_PROPERTY);
     var to = arguments.getOptionalInteger(TO_PROPERTY);
     


### PR DESCRIPTION
**Summary**
Fixes a bug in `get_scm_info` where the `commits_by_line` property is defined as boolean,
causing `Boolean cannot be cast to String` errors when invoking `/api/sources/scm`.

**Changes**
- Changed property type from boolean to string.
- Parse string into Boolean before API call.
- Tested locally against SonarQube Community Edition with and without `commits_by_line`.

 **Verification**
- `"commits_by_line" = "true"` → works 
- `"commits_by_line" = "false"` → works 
- No param → works 

**Impact**
- Prevents runtime crash.
- Aligns tool with SonarQube Web API contract.

**Example:**

- "Get SCM info for file components/shared/Spinner.tsx in project code-frontend without per-line commits." The tool fails.

**Observed Error**
```
Error executing tool get_scm_info: Tool execution failed:
An error occurred during the tool execution:
class java.lang.Boolean cannot be cast to class java.lang.String
(java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap')

```
**Root Cause**

- In GetScmInfoTool.java, commits_by_line is defined as a boolean:

 `.addBooleanProperty(COMMITS_BY_LINE_PROPERTY, ...)`

- At runtime it is read with getOptionalBoolean().

- This produces a Boolean, which is incompatible with the expected query string for the API.


