### PR TITLE
MCP-406 Migrate from Python `sonar-caas-poc` to Rust `sonar-context-augmentation`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN apk add --no-cache \
         git \
         nodejs=~24 \
         npm \
-        py3-pip \
-        python3=~3.12 \
         sudo && \
         addgroup -S appgroup && adduser -S appuser -G appgroup && \
         mkdir -p /home/appuser/.sonarlint /app/storage && \
@@ -44,27 +42,19 @@ RUN apk add --no-cache \
         chmod 0440 /etc/sudoers.d/appuser
 
 ARG TARGETARCH
-ARG SONAR_CODE_CONTEXT_VERSION=0.5.1.291
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.6.0.2
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \
         arm64) ARCH="arm64" ;; \
         *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
     esac && \
-    wget -qO- "https://binaries.sonarsource.com/Distribution/sonar-code-context-mcp-alpine-${ARCH}/sonar-code-context-mcp-alpine-${ARCH}-${SONAR_CODE_CONTEXT_VERSION}.tar.gz" \
+    wget -qO- "https://binaries.sonarsource.com/Distribution/sonar-context-augmentation-alpine-${ARCH}/sonar-context-augmentation-alpine-${ARCH}-${SONAR_CONTEXT_AUGMENTATION_VERSION}.tar.gz" \
     | tar -xz -C /tmp && \
-    install -m 755 /tmp/sonar-code-context-mcp /usr/local/bin/sonar-code-context-mcp && \
-    cp /tmp/requirements.txt /app/requirements.txt && \
-    if [ -d /tmp/wheels ]; then \
-        python3 -m pip install --no-cache-dir --break-system-packages /tmp/wheels/*.whl; \
-    fi && \
-    rm -rf /tmp/sonar-code-context-mcp /tmp/requirements.txt /tmp/wheels
+    install -m 755 /tmp/sonar-context-augmentation /usr/local/bin/sonar-context-augmentation && \
+    rm -f /tmp/sonar-context-augmentation
 
-# Install Python dependencies for sonar-code-context
 USER appuser
-RUN python3 -m pip install --no-cache-dir --break-system-packages --user -r /app/requirements.txt
-
-ENV PATH="/home/appuser/.local/bin:${PATH}"
 
 COPY --from=builder --chown=appuser:appgroup --chmod=755 /app/sonarqube-mcp-server.jar /app/sonarqube-mcp-server.jar
 COPY --chown=appuser:appgroup --chmod=755 scripts/install-certificates.sh /usr/local/bin/install-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk add --no-cache \
         chmod 0440 /etc/sudoers.d/appuser
 
 ARG TARGETARCH
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.6.0.2
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.6.0.17
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,14 @@ SOCKS5 proxies are supported.
 </details>
 
 <details>
+<summary>Third-party Dependency Tools</summary>
+
+- **check_dependency** - Check a third-party dependency for security vulnerabilities, supply-chain malware, and license compliance before adding or updating it.
+    - `purl` - Package URL (purl) with version, per [purl-spec](https://github.com/package-url/purl-spec). Format: `pkg:<type>/<namespace>/<name>@<version>` (e.g. `pkg:npm/lodash@4.17.21`, `pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1`, `pkg:pypi/django@3.2.0`) - _Required String_
+
+</details>
+
+<details>
 <summary>Context Augmentation Environment Variables</summary>
 
 | Variable                 | Description                                                        | Required | Default                 |

--- a/its/README.md
+++ b/its/README.md
@@ -29,14 +29,14 @@ its/
 │   └── resources/
 │       ├── proxied-mcp-servers-its.json
 │       └── binaries/
-│           └── sonar-code-context-mcp    # Alpine Linux binary
+│           └── sonar-context-augmentation    # Alpine Linux binary (Rust, musl)
 ```
 
 ## Architecture
 
 Tests use [Testcontainers](https://www.testcontainers.org/) to run the server and proxied server binary in Alpine Linux containers.
 
-The `sonar-code-context-mcp` binary is compiled for Alpine Linux (musl libc) and cannot run directly on most host systems.
+The `sonar-context-augmentation` binary is compiled for Alpine Linux (musl libc) and cannot run directly on most host systems.
 
 ## Test Container Dependencies
 

--- a/its/src/test/java/org/sonarsource/sonarqube/mcp/its/ProxiedServerITest.java
+++ b/its/src/test/java/org/sonarsource/sonarqube/mcp/its/ProxiedServerITest.java
@@ -33,13 +33,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * - Has correct permissions
  * - Can execute in the target environment (Alpine Linux)
  * <p>
- * Note: Tests are only enabled when the sonar-code-context-mcp binary exists in resources.
+ * Note: Tests are only enabled when the sonar-context-augmentation binary exists in resources.
  */
 @Testcontainers
 @Disabled("Waiting for a way to download the binary")
 class ProxiedServerITest {
   
-  private static final String BINARY_PATH = "binaries/sonar-code-context-mcp";
+  private static final String BINARY_PATH = "binaries/sonar-context-augmentation";
 
   @Container
   private static final GenericContainer<?> stdioServerContainer = createStdioServerContainer();
@@ -61,7 +61,7 @@ class ProxiedServerITest {
   private static GenericContainer<?> createStdioServerContainer() {
     return McpServerTestContainers.builder()
       .withProxiedServersConfig("proxied-mcp-servers-its.json")
-      .withCopyFileToContainer(BINARY_PATH, "/app/binaries/sonar-code-context-mcp", 0755)
+      .withCopyFileToContainer(BINARY_PATH, "/app/binaries/sonar-context-augmentation", 0755)
       .withStartupTimeout(Duration.ofMinutes(3))
       .withLogPrefix("STDIO-Container")
       .build();

--- a/its/src/test/resources/proxied-mcp-servers-its.json
+++ b/its/src/test/resources/proxied-mcp-servers-its.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "caas",
-    "command": "/app/binaries/sonar-code-context-mcp",
+    "command": "/app/binaries/sonar-context-augmentation",
     "args": [],
     "env": {},
     "inherits": [],

--- a/src/main/resources/proxied-mcp-servers.json
+++ b/src/main/resources/proxied-mcp-servers.json
@@ -2,7 +2,7 @@
   {
     "name": "sonar-cag",
     "transport": "stdio",
-    "command": "sonar-code-context-mcp",
+    "command": "sonar-context-augmentation",
     "args": [],
     "env": {},
     "inherits": ["SONARQUBE_URL", "SONARQUBE_TOKEN", "SONARQUBE_ORG", "SONARQUBE_PROJECT_KEY", "SONAR_SQ_BRANCH", "SONAR_WORKSPACE_DIR", "SONAR_LOG_LEVEL", "DUMP_UDG", "TELEMETRY_DISABLED"],


### PR DESCRIPTION
## Summary
- Replace the Python/Cython binary (`sonar-code-context-mcp` from `sonar-caas-poc`) with the Rust binary (`sonar-context-augmentation`) in the Docker image and proxied server config
- **Dockerfile**: download `sonar-context-augmentation` from binaries CDN, remove Python/pip dependencies (Rust binary is standalone, ~10MB vs ~60MB+ Python)
- **proxied-mcp-servers.json**: update command to `sonar-context-augmentation`
- **ITs**: update binary paths and config
- **Tools**: 10 → 11 tools — new third-party dependency toolset:
  - **`check_dependency`** - Check a third-party dependency for security vulnerabilities, supply-chain malware, and license compliance before adding or updating it.
    - `purl` - Package URL with version (e.g. `pkg:npm/lodash@4.17.21`, `pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1`, `pkg:pypi/django@3.2.0`) - _Required String_