### PR TITLE
MCP-419 Bump context augmentation from 0.6.0.17 to 0.7.0.70

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apk upgrade --no-cache && \
         chmod 0440 /etc/sudoers.d/appuser
 
 ARG TARGETARCH
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.6.0.17
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.7.0.70
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \


### PR DESCRIPTION
## Summary
- Update `SONAR_CONTEXT_AUGMENTATION_VERSION` in Dockerfile from `0.6.0.17` to `0.7.0.70`
- Fix intended architecture tool and support cross languages
