### PR TITLE
PREQ-5358 Add Copilot setup workflow on sonar-xs-public

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,24 @@
+name: "Copilot Setup Steps"
+
+# Run when this workflow is edited (validation) and allow manual runs from the Actions tab.
+# Copilot only consumes this file from the default branch — merge before relying on it in agent sessions.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be named `copilot-setup-steps` (GitHub Copilot cloud agent contract).
+  copilot-setup-steps:
+    runs-on: sonar-xs-public
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Copilot setup (self-hosted runner)
+        run: echo "Using sonar-xs-public for Copilot cloud agent setup (PREQ-5358)."


### PR DESCRIPTION
PREQ-5358 Introduces the GitHub Copilot cloud agent setup workflow so jobs can use the SonarSource self-hosted runner label `sonar-xs-public` instead of waiting on GitHub-hosted runners.

**What changed**
- Adds `.github/workflows/copilot-setup-steps.yml` with the mandatory job id `copilot-setup-steps` and `runs-on: sonar-xs-public`.
- Triggers when this workflow file changes (push/PR) and via `workflow_dispatch` for validation.

**Repo settings**
Self-hosted Copilot agents may require disabling the **Copilot cloud agent integrated firewall** on the repository if runner registration is blocked. See [Customize the agent environment](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/customize-the-agent-environment).

**Breaking changes:** None.