### PR TITLE
MCP-432 Forward mcp_server_id in _meta of InitializeRequest

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -449,7 +449,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   private void loadProxiedServerTools() {
     proxiedToolsLoader = new ProxiedToolsLoader();
     var currentTransportMode = mcpConfiguration.isHttpEnabled() ? TransportMode.HTTP : TransportMode.STDIO;
-    var proxiedTools = proxiedToolsLoader.loadProxiedTools(currentTransportMode);
+    var proxiedTools = proxiedToolsLoader.loadProxiedTools(currentTransportMode, mcpConfiguration.getMcpServerId());
     supportedTools.addAll(proxiedTools);
 
     var parseResult = ProxiedServerConfigParser.parse();

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransport.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransport.java
@@ -1,0 +1,105 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.client;
+
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import reactor.core.publisher.Mono;
+
+/**
+ * Decorator around an {@link McpClientTransport} that rewrites outgoing {@code initialize} JSON-RPC requests so that
+ * their {@code _meta} field carries startup telemetry correlation data (e.g. {@code mcp_server_id},
+ * {@code invocation_id}).
+ *
+ * <p>The MCP Java SDK's {@code McpSyncClient#initialize()} does not expose a way to set {@code _meta} on the
+ * {@link McpSchema.InitializeRequest} it builds internally. By wrapping the underlying transport, we can intercept the
+ * outgoing message and rebuild it with meta populated — mirroring what {@code ToolExecutor} already does for
+ * {@code tools/call}. All other transport responsibilities are delegated unchanged.
+ */
+public class InitializeMetaInjectingClientTransport implements McpClientTransport {
+
+  private final McpClientTransport delegate;
+  private final Map<String, Object> initializeMeta;
+
+  public InitializeMetaInjectingClientTransport(McpClientTransport delegate, Map<String, Object> initializeMeta) {
+    this.delegate = delegate;
+    this.initializeMeta = Map.copyOf(initializeMeta);
+  }
+
+  @Override
+  public Mono<Void> connect(Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+    return delegate.connect(handler);
+  }
+
+  @Override
+  public void setExceptionHandler(Consumer<Throwable> handler) {
+    delegate.setExceptionHandler(handler);
+  }
+
+  @Override
+  public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+    return delegate.sendMessage(maybeInjectInitializeMeta(message));
+  }
+
+  @Override
+  public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+    return delegate.unmarshalFrom(data, typeRef);
+  }
+
+  @Override
+  public Mono<Void> closeGracefully() {
+    return delegate.closeGracefully();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public List<String> protocolVersions() {
+    return delegate.protocolVersions();
+  }
+
+  McpSchema.JSONRPCMessage maybeInjectInitializeMeta(McpSchema.JSONRPCMessage message) {
+    if (initializeMeta.isEmpty()) {
+      return message;
+    }
+    if (message instanceof McpSchema.JSONRPCRequest(String jsonrpc, String method, Object id, Object params)
+      && McpSchema.METHOD_INITIALIZE.equals(method)
+      && params instanceof McpSchema.InitializeRequest(
+      String protocolVersion, McpSchema.ClientCapabilities capabilities,
+      McpSchema.Implementation clientInfo, Map<String, Object> existingMeta
+    )) {
+      var merged = new HashMap<String, Object>();
+      if (existingMeta != null) {
+        merged.putAll(existingMeta);
+      }
+      merged.putAll(initializeMeta);
+      return new McpSchema.JSONRPCRequest(jsonrpc, method, id,
+        new McpSchema.InitializeRequest(protocolVersion, capabilities, clientInfo, merged));
+    }
+    return message;
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransport.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransport.java
@@ -31,7 +31,8 @@ import reactor.core.publisher.Mono;
  * their {@code _meta} field carries startup telemetry correlation data (e.g. {@code mcp_server_id},
  * {@code invocation_id}).
  *
- * <p>The MCP Java SDK's {@code McpSyncClient#initialize()} does not expose a way to set {@code _meta} on the
+ * <p>The MCP Java SDK's {@code McpSyncClient#initialize()} does not expose
+ * (<a href="https://github.com/modelcontextprotocol/java-sdk/issues/940">#940</a>) a way to set {@code _meta} on the
  * {@link McpSchema.InitializeRequest} it builds internally. By wrapping the underlying transport, we can intercept the
  * outgoing message and rebuild it with meta populated — mirroring what {@code ToolExecutor} already does for
  * {@code tools/call}. All other transport responsibilities are delegated unchanged.
@@ -43,7 +44,7 @@ public class InitializeMetaInjectingClientTransport implements McpClientTranspor
 
   public InitializeMetaInjectingClientTransport(McpClientTransport delegate, Map<String, Object> initializeMeta) {
     this.delegate = delegate;
-    this.initializeMeta = Map.copyOf(initializeMeta);
+    this.initializeMeta = initializeMeta;
   }
 
   @Override
@@ -82,9 +83,6 @@ public class InitializeMetaInjectingClientTransport implements McpClientTranspor
   }
 
   McpSchema.JSONRPCMessage maybeInjectInitializeMeta(McpSchema.JSONRPCMessage message) {
-    if (initializeMeta.isEmpty()) {
-      return message;
-    }
     if (message instanceof McpSchema.JSONRPCRequest(String jsonrpc, String method, Object id, Object params)
       && McpSchema.METHOD_INITIALIZE.equals(method)
       && params instanceof McpSchema.InitializeRequest(

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransport.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransport.java
@@ -28,8 +28,7 @@ import reactor.core.publisher.Mono;
 
 /**
  * Decorator around an {@link McpClientTransport} that rewrites outgoing {@code initialize} JSON-RPC requests so that
- * their {@code _meta} field carries startup telemetry correlation data (e.g. {@code mcp_server_id},
- * {@code invocation_id}).
+ * their {@code _meta} field carries startup telemetry correlation data (e.g. {@code mcp_server_id}.
  *
  * <p>The MCP Java SDK's {@code McpSyncClient#initialize()} does not expose
  * (<a href="https://github.com/modelcontextprotocol/java-sdk/issues/940">#940</a>) a way to set {@code _meta} on the

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
@@ -20,11 +20,13 @@ import com.google.common.annotations.VisibleForTesting;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.ServerParameters;
+import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
@@ -45,13 +47,15 @@ public class McpClientManager {
     Integer.parseInt(System.getProperty("mcp.client.init.timeout.seconds", "60")));
   
   private final List<ProxiedMcpServerConfig> serverConfigs;
+  private final String mcpServerId;
   private final Map<String, McpSyncClient> clients = new ConcurrentHashMap<>();
   private final Map<String, List<McpSchema.Tool>> serverTools = new ConcurrentHashMap<>();
   private final Map<String, String> serverErrors = new ConcurrentHashMap<>();
   private volatile boolean initialized = false;
-  
-  public McpClientManager(List<ProxiedMcpServerConfig> serverConfigs) {
+
+  public McpClientManager(List<ProxiedMcpServerConfig> serverConfigs, String mcpServerId) {
     this.serverConfigs = List.copyOf(serverConfigs);
+    this.mcpServerId = mcpServerId;
   }
 
   public void initialize() {
@@ -104,8 +108,9 @@ public class McpClientManager {
       serverParamsBuilder.env(filteredEnv);
 
       var serverParams = serverParamsBuilder.build();
-      var transport = new ManagedStdioClientTransport(config.name(), serverParams, McpJsonMappers.DEFAULT);
-      transport.setStdErrorHandler(line -> LOG.debug("[" + config.name() + "] stderr: " + line));
+      var stdioTransport = new ManagedStdioClientTransport(config.name(), serverParams, McpJsonMappers.DEFAULT);
+      stdioTransport.setStdErrorHandler(line -> LOG.debug("[" + config.name() + "] stderr: " + line));
+      var transport = wrapWithInitializeMeta(stdioTransport);
 
       var client = McpClient.sync(transport)
         .requestTimeout(DEFAULT_REQUEST_TIMEOUT)
@@ -229,6 +234,13 @@ public class McpClientManager {
     }
     
     return filteredEnv;
+  }
+
+  private McpClientTransport wrapWithInitializeMeta(McpClientTransport transport) {
+    var meta = Map.<String, Object>of(
+      "mcp_server_id", mcpServerId,
+      "invocation_id", UUID.randomUUID().toString());
+    return new InitializeMetaInjectingClientTransport(transport, meta);
   }
 
   public record ToolMapping(String serverId, String originalToolName, McpSchema.Tool tool) {}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
@@ -237,9 +236,7 @@ public class McpClientManager {
   }
 
   private McpClientTransport wrapWithInitializeMeta(McpClientTransport transport) {
-    var meta = Map.<String, Object>of(
-      "mcp_server_id", mcpServerId,
-      "invocation_id", UUID.randomUUID().toString());
+    var meta = Map.<String, Object>of("mcp_server_id", mcpServerId);
     return new InitializeMetaInjectingClientTransport(transport, meta);
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoader.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoader.java
@@ -38,7 +38,7 @@ public class ProxiedToolsLoader {
    * 5. Discovers tools from connected servers
    * 6. Creates tool wrappers for integration
    */
-  public List<Tool> loadProxiedTools(TransportMode currentTransportMode) {
+  public List<Tool> loadProxiedTools(TransportMode currentTransportMode, String mcpServerId) {
     var parseResult = ProxiedServerConfigParser.parse();
     
     if (!parseResult.success()) {
@@ -88,7 +88,7 @@ public class ProxiedToolsLoader {
     LOG.info("Initializing " + reachableConfigs.size() + " proxied MCP server(s)...");
     
     try {
-      mcpClientManager = new McpClientManager(reachableConfigs);
+      mcpClientManager = new McpClientManager(reachableConfigs, mcpServerId);
       mcpClientManager.initialize();
 
       var tools = mcpClientManager.getAllProxiedTools().values().stream()

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransportTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransportTest.java
@@ -1,0 +1,208 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.client;
+
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InitializeMetaInjectingClientTransportTest {
+
+  @Test
+  void sendMessage_should_populate_meta_on_initialize_request() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture,
+      Map.of("mcp_server_id", "server-123", "invocation_id", "inv-abc"));
+
+    var message = initializeMessage(null);
+
+    transport.sendMessage(message).block();
+
+    var sent = (McpSchema.JSONRPCRequest) capture.lastMessage.get();
+    assertThat(sent.method()).isEqualTo(McpSchema.METHOD_INITIALIZE);
+    var init = (McpSchema.InitializeRequest) sent.params();
+    assertThat(init.meta())
+      .containsEntry("mcp_server_id", "server-123")
+      .containsEntry("invocation_id", "inv-abc");
+  }
+
+  @Test
+  void sendMessage_should_merge_with_pre_existing_meta() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture,
+      Map.of("mcp_server_id", "server-123"));
+
+    var message = initializeMessage(Map.of("existing_key", "existing_value"));
+
+    transport.sendMessage(message).block();
+
+    var sent = (McpSchema.JSONRPCRequest) capture.lastMessage.get();
+    var init = (McpSchema.InitializeRequest) sent.params();
+    assertThat(init.meta())
+      .containsEntry("existing_key", "existing_value")
+      .containsEntry("mcp_server_id", "server-123");
+  }
+
+  @Test
+  void sendMessage_should_override_pre_existing_meta_with_injected_values_on_conflict() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture,
+      Map.of("mcp_server_id", "injected-id"));
+
+    var message = initializeMessage(Map.of("mcp_server_id", "original-id", "other_key", "other_value"));
+
+    transport.sendMessage(message).block();
+
+    var sent = (McpSchema.JSONRPCRequest) capture.lastMessage.get();
+    var init = (McpSchema.InitializeRequest) sent.params();
+    assertThat(init.meta())
+      .containsEntry("mcp_server_id", "injected-id")
+      .containsEntry("other_key", "other_value");
+  }
+
+  @Test
+  void sendMessage_should_pass_through_when_meta_is_empty() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture, Map.of());
+
+    var message = initializeMessage(null);
+
+    transport.sendMessage(message).block();
+
+    assertThat(capture.lastMessage.get()).isSameAs(message);
+  }
+
+  @Test
+  void sendMessage_should_not_touch_non_initialize_requests() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture, Map.of("mcp_server_id", "server-123"));
+
+    var callToolRequest = new McpSchema.CallToolRequest("some_tool", Map.of(), null);
+    var message = new McpSchema.JSONRPCRequest("2.0", McpSchema.METHOD_TOOLS_CALL, 2, callToolRequest);
+
+    transport.sendMessage(message).block();
+
+    assertThat(capture.lastMessage.get()).isSameAs(message);
+  }
+
+  @Test
+  void sendMessage_should_not_touch_notifications() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture, Map.of("mcp_server_id", "server-123"));
+
+    var notification = new McpSchema.JSONRPCNotification("2.0", McpSchema.METHOD_NOTIFICATION_INITIALIZED, null);
+
+    transport.sendMessage(notification).block();
+
+    assertThat(capture.lastMessage.get()).isSameAs(notification);
+  }
+
+  @Test
+  void constructor_should_defensively_copy_meta() {
+    var capture = new CapturingTransport();
+    var meta = new HashMap<String, Object>();
+    meta.put("mcp_server_id", "server-123");
+    var transport = new InitializeMetaInjectingClientTransport(capture, meta);
+
+    meta.clear();
+
+    transport.sendMessage(initializeMessage(null)).block();
+
+    var sent = (McpSchema.JSONRPCRequest) capture.lastMessage.get();
+    var init = (McpSchema.InitializeRequest) sent.params();
+    assertThat(init.meta()).containsEntry("mcp_server_id", "server-123");
+  }
+
+  @Test
+  void delegate_methods_should_forward_to_wrapped_transport() {
+    var capture = new CapturingTransport();
+    var transport = new InitializeMetaInjectingClientTransport(capture, Map.of("mcp_server_id", "x"));
+
+    Consumer<Throwable> handler = t -> {};
+    transport.setExceptionHandler(handler);
+    transport.closeGracefully().block();
+    var protocols = transport.protocolVersions();
+
+    assertThat(capture.exceptionHandler.get()).isSameAs(handler);
+    assertThat(capture.closeGracefullyCalled.get()).isTrue();
+    assertThat(protocols).isEqualTo(capture.protocolVersions());
+  }
+
+  private static McpSchema.JSONRPCRequest initializeMessage(Map<String, Object> meta) {
+    McpSchema.InitializeRequest init = meta == null
+      ? new McpSchema.InitializeRequest("2024-11-05",
+          McpSchema.ClientCapabilities.builder().build(),
+          new McpSchema.Implementation("client", "1.0"))
+      : new McpSchema.InitializeRequest("2024-11-05",
+          McpSchema.ClientCapabilities.builder().build(),
+          new McpSchema.Implementation("client", "1.0"),
+          meta);
+    return new McpSchema.JSONRPCRequest("2.0", McpSchema.METHOD_INITIALIZE, 1, init);
+  }
+
+  /**
+   * Minimal transport stub capturing sent messages and delegate interactions.
+   */
+  private static final class CapturingTransport implements McpClientTransport {
+    final AtomicReference<McpSchema.JSONRPCMessage> lastMessage = new AtomicReference<>();
+    final AtomicReference<Consumer<Throwable>> exceptionHandler = new AtomicReference<>();
+    final AtomicReference<Boolean> closeGracefullyCalled = new AtomicReference<>(false);
+
+    @Override
+    public Mono<Void> connect(Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+      return Mono.empty();
+    }
+
+    @Override
+    public void setExceptionHandler(Consumer<Throwable> handler) {
+      exceptionHandler.set(handler);
+    }
+
+    @Override
+    public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+      lastMessage.set(message);
+      return Mono.empty();
+    }
+
+    @Override
+    public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+      return null;
+    }
+
+    @Override
+    public Mono<Void> closeGracefully() {
+      closeGracefullyCalled.set(true);
+      return Mono.empty();
+    }
+
+    @Override
+    public List<String> protocolVersions() {
+      return List.of("2024-11-05");
+    }
+  }
+
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransportTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/InitializeMetaInjectingClientTransportTest.java
@@ -19,7 +19,6 @@ package org.sonarsource.sonarqube.mcp.client;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,7 +35,7 @@ class InitializeMetaInjectingClientTransportTest {
   void sendMessage_should_populate_meta_on_initialize_request() {
     var capture = new CapturingTransport();
     var transport = new InitializeMetaInjectingClientTransport(capture,
-      Map.of("mcp_server_id", "server-123", "invocation_id", "inv-abc"));
+      Map.of("mcp_server_id", "server-123"));
 
     var message = initializeMessage(null);
 
@@ -45,9 +44,7 @@ class InitializeMetaInjectingClientTransportTest {
     var sent = (McpSchema.JSONRPCRequest) capture.lastMessage.get();
     assertThat(sent.method()).isEqualTo(McpSchema.METHOD_INITIALIZE);
     var init = (McpSchema.InitializeRequest) sent.params();
-    assertThat(init.meta())
-      .containsEntry("mcp_server_id", "server-123")
-      .containsEntry("invocation_id", "inv-abc");
+    assertThat(init.meta()).containsEntry("mcp_server_id", "server-123");
   }
 
   @Test
@@ -85,18 +82,6 @@ class InitializeMetaInjectingClientTransportTest {
   }
 
   @Test
-  void sendMessage_should_pass_through_when_meta_is_empty() {
-    var capture = new CapturingTransport();
-    var transport = new InitializeMetaInjectingClientTransport(capture, Map.of());
-
-    var message = initializeMessage(null);
-
-    transport.sendMessage(message).block();
-
-    assertThat(capture.lastMessage.get()).isSameAs(message);
-  }
-
-  @Test
   void sendMessage_should_not_touch_non_initialize_requests() {
     var capture = new CapturingTransport();
     var transport = new InitializeMetaInjectingClientTransport(capture, Map.of("mcp_server_id", "server-123"));
@@ -119,22 +104,6 @@ class InitializeMetaInjectingClientTransportTest {
     transport.sendMessage(notification).block();
 
     assertThat(capture.lastMessage.get()).isSameAs(notification);
-  }
-
-  @Test
-  void constructor_should_defensively_copy_meta() {
-    var capture = new CapturingTransport();
-    var meta = new HashMap<String, Object>();
-    meta.put("mcp_server_id", "server-123");
-    var transport = new InitializeMetaInjectingClientTransport(capture, meta);
-
-    meta.clear();
-
-    transport.sendMessage(initializeMessage(null)).block();
-
-    var sent = (McpSchema.JSONRPCRequest) capture.lastMessage.get();
-    var init = (McpSchema.InitializeRequest) sent.params();
-    assertThat(init.meta()).containsEntry("mcp_server_id", "server-123");
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/McpClientManagerTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/McpClientManagerTest.java
@@ -19,6 +19,7 @@ package org.sonarsource.sonarqube.mcp.client;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +29,7 @@ class McpClientManagerTest {
 
   @Test
   void constructor_should_accept_empty_list() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
 
     assertThat(manager.getTotalCount()).isZero();
     assertThat(manager.isInitialized()).isFalse();
@@ -37,7 +38,7 @@ class McpClientManagerTest {
 
   @Test
   void initialize_should_be_idempotent() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
 
     manager.initialize();
     assertThat(manager.isInitialized()).isTrue();
@@ -53,7 +54,7 @@ class McpClientManagerTest {
       new ProxiedMcpServerConfig("server2", "uv", List.of(), Map.of(), List.of(), Set.of(TransportMode.STDIO), null)
     );
 
-    var manager = new McpClientManager(configs);
+    var manager = new McpClientManager(configs, UUID.randomUUID().toString());
 
     assertThat(manager.getTotalCount()).isEqualTo(2);
   }
@@ -62,7 +63,7 @@ class McpClientManagerTest {
   void getAllProxiedTools_should_return_empty_map_before_initialization() {
     var configs = List.of(new ProxiedMcpServerConfig("server1", "npx", List.of(), Map.of(), List.of(), Set.of(TransportMode.STDIO), null));
 
-    var manager = new McpClientManager(configs);
+    var manager = new McpClientManager(configs, UUID.randomUUID().toString());
 
     // Before initialization, no tools discovered
     assertThat(manager.getAllProxiedTools()).isEmpty();
@@ -70,7 +71,7 @@ class McpClientManagerTest {
 
   @Test
   void isServerConnected_should_return_false_for_unknown_server() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
 
     manager.initialize();
 
@@ -79,7 +80,7 @@ class McpClientManagerTest {
 
   @Test
   void executeTool_should_throw_when_server_not_connected() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var emptyMap = Map.<String, Object>of();
 
     manager.initialize();
@@ -91,7 +92,7 @@ class McpClientManagerTest {
 
   @Test
   void shutdown_should_clear_state() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     manager.initialize();
 
     manager.shutdown();
@@ -103,7 +104,7 @@ class McpClientManagerTest {
   @Test
   void executeTool_should_include_error_message_for_failed_server() {
     var configs = List.of(new ProxiedMcpServerConfig("failing-server", "/non/existent/command", List.of(), Map.of(), List.of(), Set.of(TransportMode.STDIO), null));
-    var manager = new McpClientManager(configs);
+    var manager = new McpClientManager(configs, UUID.randomUUID().toString());
     var emptyMap = Map.<String, Object>of();
 
     manager.initialize();
@@ -115,7 +116,7 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_include_explicit_values_from_config() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(), 
       Map.of("EXPLICIT_VAR1", "value1", "EXPLICIT_VAR2", "value2"), 
       List.of(), Set.of(TransportMode.STDIO), null);
@@ -132,7 +133,7 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_inherit_variables_from_parent() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(), 
       Map.of(), 
       List.of("INHERITED_VAR1", "INHERITED_VAR2"), 
@@ -154,7 +155,7 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_prioritize_explicit_values_over_inherited() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(), 
       Map.of("OVERRIDE_VAR", "explicit_value"), 
       List.of("OVERRIDE_VAR"), 
@@ -170,7 +171,7 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_skip_inherited_var_not_in_parent() {
-    var manager = new McpClientManager(List.of());
+    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(), 
       Map.of(), 
       List.of("MISSING_VAR", "EXISTING_VAR"), 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderMediumTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderMediumTest.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,7 +104,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     assertThat(tools)
       .isNotEmpty()
@@ -125,7 +127,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     assertThat(tools)
       .isNotEmpty()
@@ -147,7 +149,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     var tool1 = tools.stream()
       .filter(t -> t.definition().name().equals("test_tool_1"))
@@ -181,7 +183,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     // Note: Without namespace prefixing, we'll only get 2 tools since both servers expose the same tool names
     // The second server's tools will overwrite the first server's tools in the map
@@ -211,7 +213,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     assertThat(tools).hasSize(2);
     var toolNames2 = tools.stream().map(t -> t.definition().name()).toList();
@@ -232,7 +234,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     // The test server includes the TEST_ENV_VAR in the tool description
     var tool1 = tools.stream()
@@ -259,7 +261,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     // Server should load successfully even with empty env values
     // If PATH wasn't inherited, python3 command wouldn't be found
@@ -286,7 +288,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     // The test server includes TEST_ENV_VAR in the tool description
     var tool1 = tools.stream()
@@ -310,7 +312,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     var tool1 = (ProxiedMcpTool) tools.stream()
       .filter(t -> t.definition().name().equals("test_tool_1"))
@@ -343,7 +345,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     var tool2 = (ProxiedMcpTool) tools.stream()
       .filter(t -> t.definition().name().equals("test_tool_2"))
@@ -374,7 +376,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     var tool2 = (ProxiedMcpTool) tools.stream()
       .filter(t -> t.definition().name().equals("test_tool_1"))
@@ -391,6 +393,36 @@ class ProxiedToolsLoaderMediumTest {
     var callToolResult = result.toCallToolResult();
     var textContent = (McpSchema.TextContent) callToolResult.content().getFirst();
     assertThat(textContent.text()).contains("Test Tool 1 executed with input: None");
+  }
+
+  @Test
+  void loadProxiedTools_should_forward_mcp_server_id_in_initialize_meta() throws IOException {
+    var capturePath = Files.createTempFile("init-meta-", ".json");
+    Files.deleteIfExists(capturePath);
+    try {
+      createTestConfig(List.of(
+        Map.of(
+          "name", "test-server",
+          "command", "python3",
+          "args", List.of(testServerScript.toString()),
+          "env", Map.of("TEST_CAPTURE_INIT_META_PATH", capturePath.toString()),
+          "supportedTransports", Set.of("stdio")
+        )
+      ));
+
+      loader = new ProxiedToolsLoader();
+      var tools = loader.loadProxiedTools(TransportMode.STDIO, "server-uuid-42");
+
+      assertThat(tools).isNotEmpty();
+      assertThat(capturePath).exists();
+      var capturedMeta = OBJECT_MAPPER.readValue(capturePath.toFile(), new TypeReference<Map<String, Object>>() {});
+      assertThat(capturedMeta)
+        .containsEntry("mcp_server_id", "server-uuid-42")
+        .containsKey("invocation_id");
+      assertThat(capturedMeta.get("invocation_id")).isInstanceOf(String.class).asString().isNotBlank();
+    } finally {
+      Files.deleteIfExists(capturePath);
+    }
   }
 
   @Test
@@ -414,7 +446,7 @@ class ProxiedToolsLoaderMediumTest {
     ));
 
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     assertThat(tools).isEmpty();
   }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderMediumTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderMediumTest.java
@@ -416,10 +416,7 @@ class ProxiedToolsLoaderMediumTest {
       assertThat(tools).isNotEmpty();
       assertThat(capturePath).exists();
       var capturedMeta = OBJECT_MAPPER.readValue(capturePath.toFile(), new TypeReference<Map<String, Object>>() {});
-      assertThat(capturedMeta)
-        .containsEntry("mcp_server_id", "server-uuid-42")
-        .containsKey("invocation_id");
-      assertThat(capturedMeta.get("invocation_id")).isInstanceOf(String.class).asString().isNotBlank();
+      assertThat(capturedMeta).containsEntry("mcp_server_id", "server-uuid-42");
     } finally {
       Files.deleteIfExists(capturePath);
     }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderTest.java
@@ -17,6 +17,7 @@
 package org.sonarsource.sonarqube.mcp.client;
 
 import java.nio.file.Path;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -38,7 +39,7 @@ class ProxiedToolsLoaderTest {
   @Test
   void loadProxiedTools_should_return_empty_when_no_servers_configured() {
     loader = new ProxiedToolsLoader();
-    var tools = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     assertThat(tools).isEmpty();
   }
@@ -46,7 +47,7 @@ class ProxiedToolsLoaderTest {
   @Test
   void shutdown_should_not_fail_when_called_multiple_times() {
     loader = new ProxiedToolsLoader();
-    loader.loadProxiedTools(TransportMode.STDIO);
+    loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
 
     assertThatCode(() -> {
       loader.shutdown();
@@ -60,8 +61,8 @@ class ProxiedToolsLoaderTest {
     var loader1 = new ProxiedToolsLoader();
     var loader2 = new ProxiedToolsLoader();
 
-    var tools1 = loader1.loadProxiedTools(TransportMode.STDIO);
-    var tools2 = loader2.loadProxiedTools(TransportMode.HTTP);
+    var tools1 = loader1.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
+    var tools2 = loader2.loadProxiedTools(TransportMode.HTTP, UUID.randomUUID().toString());
 
     assertThat(tools1).isNotNull().isEmpty();
     assertThat(tools2).isNotNull().isEmpty();
@@ -74,11 +75,11 @@ class ProxiedToolsLoaderTest {
   void loadProxiedTools_after_shutdown_should_work() {
     loader = new ProxiedToolsLoader();
     
-    var tools1 = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools1 = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
     loader.shutdown();
     
     // Loading again after shutdown should still work
-    var tools2 = loader.loadProxiedTools(TransportMode.STDIO);
+    var tools2 = loader.loadProxiedTools(TransportMode.STDIO, UUID.randomUUID().toString());
     
     assertThat(tools1).isNotNull();
     assertThat(tools2).isNotNull();

--- a/src/test/resources/test-mcp-server.py
+++ b/src/test/resources/test-mcp-server.py
@@ -45,6 +45,17 @@ def receive_message():
 
 def handle_initialize(request):
     """Handle the initialize request"""
+    # Optionally capture the _meta field to a file (for tests that assert on startup meta).
+    capture_path = os.environ.get("TEST_CAPTURE_INIT_META_PATH")
+    if capture_path:
+        params = request.get("params") or {}
+        meta = params.get("_meta")
+        try:
+            with open(capture_path, "w") as f:
+                json.dump(meta if meta is not None else {}, f)
+        except Exception:
+            pass
+
     send_message({
         "jsonrpc": "2.0",
         "id": request.get("id"),


### PR DESCRIPTION
Not ideal due to SDK limitation, issue on their side: https://github.com/modelcontextprotocol/java-sdk/issues/940