### PR TITLE
CAG-326 Pin CAG 0.8.0.355

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.7.0.70
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.8.0.355
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.18-SNAPSHOT
-sonarContextAugmentationVersion=0.7.0.70
+sonarContextAugmentationVersion=0.8.0.355
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true


### PR DESCRIPTION
## Summary
- Update the bundled CAG binary version to `0.8.0.355`.
- Keep `gradle.properties` and the Dockerfile default build argument in sync.

