### PR TITLE
Redirect certificate installation logs to stderr in Docker stdio mode

### DIFF
--- a/scripts/install-certificates.sh
+++ b/scripts/install-certificates.sh
@@ -8,7 +8,7 @@ if [ "$(ls -A "$CERT_DIR")" ]; then
     echo "Installing custom certificates from $CERT_DIR..." >&2
 
     # Run as root via sudo
-    sudo /usr/sbin/update-ca-certificates
+    sudo /usr/sbin/update-ca-certificates >&2
 
     echo "Custom certificates installed successfully" >&2
 fi

--- a/scripts/install-certificates.sh
+++ b/scripts/install-certificates.sh
@@ -5,10 +5,10 @@
 CERT_DIR="/usr/local/share/ca-certificates/"
 
 if [ "$(ls -A "$CERT_DIR")" ]; then
-    echo "Installing custom certificates from $CERT_DIR..."
+    echo "Installing custom certificates from $CERT_DIR..." >&2
 
     # Run as root via sudo
     sudo /usr/sbin/update-ca-certificates
 
-    echo "Custom certificates installed successfully"
+    echo "Custom certificates installed successfully" >&2
 fi


### PR DESCRIPTION
Title: Redirect certificate installation logs to stderr in Docker stdio mode

## Summary

This change redirects certificate installation informational messages from `stdout` to `stderr` in `scripts/install-certificates.sh`.

## Why

The Docker image is commonly used as an MCP stdio server.
In stdio mode, `stdout` must remain reserved for JSON-RPC protocol traffic.

When custom certificates are mounted into `/usr/local/share/ca-certificates/`, the current script writes:

- `Installing custom certificates from ...`
- `Custom certificates installed successfully`

to `stdout` before the Java MCP server starts.

That can break MCP clients during handshake.

## Change

- redirect the two informational `echo` calls to `stderr`

## Effect

- no behavior change for certificate installation itself
- logs remain visible
- `stdout` stays clean for MCP stdio clients

## Validation

Reproduced with a container run that mounts custom certificates into `/usr/local/share/ca-certificates/`.

Before this patch:

- informational certificate messages appeared on `stdout`

After this patch:

- `stdout` stays empty before MCP traffic
- certificate and warning messages are emitted on `stderr`
