### PR TITLE
Fix missing @Nullable on optional Issue fields causing outputSchema validation errors

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolResponse.java
@@ -35,12 +35,12 @@ public record SearchIssuesToolResponse(
     @JsonPropertyDescription("Rule that triggered the issue") String rule,
     @JsonPropertyDescription("Project key where the issue was found") String project,
     @JsonPropertyDescription("Component (file) where the issue is located") String component,
-    @JsonPropertyDescription("Issue severity level (absent in MQR mode)") @Nullable String severity,
+    @JsonPropertyDescription("Issue severity level") @Nullable String severity,
     @JsonPropertyDescription("Current status of the issue") String status,
     @JsonPropertyDescription("Issue description message") String message,
-    @JsonPropertyDescription("Clean code attribute associated with the issue (absent on legacy rules or older SonarQube Server)") @Nullable String cleanCodeAttribute,
-    @JsonPropertyDescription("Clean code attribute category (absent on legacy rules or older SonarQube Server)") @Nullable String cleanCodeAttributeCategory,
-    @JsonPropertyDescription("Author who introduced the issue (absent when SCM blame unavailable, or anonymized)") @Nullable String author,
+    @JsonPropertyDescription("Clean code attribute associated with the issue") @Nullable String cleanCodeAttribute,
+    @JsonPropertyDescription("Clean code attribute category") @Nullable String cleanCodeAttributeCategory,
+    @JsonPropertyDescription("Author who introduced the issue") @Nullable String author,
     @JsonPropertyDescription("Date when the issue was created") String creationDate,
     @JsonPropertyDescription("Location of the issue in the source file") @Nullable TextRange textRange
   ) {}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolResponse.java
@@ -35,12 +35,12 @@ public record SearchIssuesToolResponse(
     @JsonPropertyDescription("Rule that triggered the issue") String rule,
     @JsonPropertyDescription("Project key where the issue was found") String project,
     @JsonPropertyDescription("Component (file) where the issue is located") String component,
-    @JsonPropertyDescription("Issue severity level") String severity,
+    @JsonPropertyDescription("Issue severity level (absent in MQR mode)") @Nullable String severity,
     @JsonPropertyDescription("Current status of the issue") String status,
     @JsonPropertyDescription("Issue description message") String message,
-    @JsonPropertyDescription("Clean code attribute associated with the issue") String cleanCodeAttribute,
-    @JsonPropertyDescription("Clean code attribute category") String cleanCodeAttributeCategory,
-    @JsonPropertyDescription("Author who introduced the issue") String author,
+    @JsonPropertyDescription("Clean code attribute associated with the issue (absent on legacy rules or older SonarQube Server)") @Nullable String cleanCodeAttribute,
+    @JsonPropertyDescription("Clean code attribute category (absent on legacy rules or older SonarQube Server)") @Nullable String cleanCodeAttributeCategory,
+    @JsonPropertyDescription("Author who introduced the issue (absent when SCM blame unavailable, or anonymized)") @Nullable String author,
     @JsonPropertyDescription("Date when the issue was created") String creationDate,
     @JsonPropertyDescription("Location of the issue in the source file") @Nullable TextRange textRange
   ) {}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
@@ -121,16 +121,12 @@ class SearchIssuesToolTests {
                      }
                   },
                   "required":[
-                     "author",
-                     "cleanCodeAttribute",
-                     "cleanCodeAttributeCategory",
                      "component",
                      "creationDate",
                      "key",
                      "message",
                      "project",
                      "rule",
-                     "severity",
                      "status"
                   ]
                }
@@ -572,6 +568,50 @@ class SearchIssuesToolTests {
         }""");
       assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
         .contains(new ReceivedRequest("Bearer token", ""));
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_handle_issues_with_null_author_and_other_optional_fields(SonarQubeMcpServerTestHarness harness) {
+      var issueKey = "issueKey1";
+      var ruleName = "ruleName1";
+      var projectName = "projectName1";
+      harness.getMockSonarQubeServer().stubFor(get(IssuesApi.SEARCH_PATH + "?organization=org")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes("""
+            {
+                "paging": {
+                  "pageIndex": 1,
+                  "pageSize": 100,
+                  "total": 1
+                },
+                "issues": [%s],
+                "components": [],
+                "rules": [],
+                "users": []
+              }
+            """.formatted(generateIssueWithNullOptionalFields(issueKey, ruleName, projectName)).getBytes(StandardCharsets.UTF_8)))));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      var result = mcpClient.callTool(SearchIssuesTool.TOOL_NAME);
+
+      assertResultEquals(result, """
+        {
+          "issues" : [ {
+            "key" : "issueKey1",
+            "rule" : "ruleName1",
+            "project" : "projectName1",
+            "component" : "com.github.kevinsawicki:http-request:com.github.kevinsawicki.http.HttpRequest",
+            "status" : "RESOLVED",
+            "message" : "'3' is a magic number.",
+            "creationDate" : "2013-05-13T17:55:39+0200"
+          } ],
+          "paging" : {
+            "pageIndex" : 1,
+            "pageSize" : 100,
+            "total" : 1
+          }
+        }""");
     }
 
     @SonarQubeMcpServerTest
@@ -1374,6 +1414,38 @@ class SearchIssuesToolTests {
         "ruleDescriptionContextKey": "spring",
         "cleanCodeAttributeCategory": "INTENTIONAL",
         "cleanCodeAttribute": "CLEAR",
+        "impacts": [
+          {
+            "softwareQuality": "MAINTAINABILITY",
+            "severity": "HIGH"
+          }
+        ]
+      }""".formatted(issueKey, projectName, ruleName);
+  }
+
+  private static String generateIssueWithNullOptionalFields(String issueKey, String ruleName, String projectName) {
+    return """
+        {
+        "key": "%s",
+        "component": "com.github.kevinsawicki:http-request:com.github.kevinsawicki.http.HttpRequest",
+        "project": "%s",
+        "rule": "%s",
+        "issueStatus": "CLOSED",
+        "status": "RESOLVED",
+        "resolution": "FALSE-POSITIVE",
+        "message": "'3' is a magic number.",
+        "line": 81,
+        "hash": "a227e508d6646b55a086ee11d63b21e9",
+        "effort": "2h1min",
+        "creationDate": "2013-05-13T17:55:39+0200",
+        "updateDate": "2013-05-13T17:55:39+0200",
+        "tags": [],
+        "type": "RELIABILITY",
+        "comments": [],
+        "attr": {},
+        "transitions": [],
+        "actions": [],
+        "flows": [],
         "impacts": [
           {
             "softwareQuality": "MAINTAINABILITY",


### PR DESCRIPTION
* Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube-mcp-server/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/MCP) ticket available, please make your commits and pull request start with the ticket ID (MCP-XXXX)

---

## Problem

`search_sonar_issues_in_projects` returns a `tools/call` validation error whenever the SonarQube response contains an issue where `author` (or other optional fields) is absent. This makes the tool effectively unusable for any project that includes such issues, and there is no argument-level workaround available to the user.

The root cause is a mismatch between two mechanisms in `SchemaUtils`:

1. `withRequiredCheck` marks every field without `@Nullable` as `required` in the generated `outputSchema`.
2. `ObjectMapper` is configured with `JsonInclude.Include.NON_NULL`, which silently omits null fields from the serialized payload.

When SonarQube legitimately omits a field (e.g. `author` when SCM blame has not been performed), the Java field is set to `null` by Gson, the serializer drops the key, and the resulting payload fails the `required` constraint in the MCP `outputSchema`. Because this can affect any issue in the response, filtering or pagination arguments cannot work around it.

## Fix

Added `@Nullable` to the four fields in `SearchIssuesToolResponse.Issue` that SonarQube can legitimately omit:

| Field | When absent |
|---|---|
| `author` | SCM blame not run, external/imported issue, or user anonymization (SonarQube Cloud) |
| `severity` | MQR (Multi-Quality Rating) mode — legacy single severity is replaced by `impacts[]` |
| `cleanCodeAttribute` | Legacy rules or older SonarQube Server versions |
| `cleanCodeAttributeCategory` | Same as `cleanCodeAttribute` |

With `@Nullable` in place, `SchemaUtils.withRequiredCheck` excludes these fields from the `required` array in the output schema, so a missing field no longer causes a validation failure. The fields remain in `properties`, so clients that do receive them can still consume them normally.

## Tests

- Updated `it_should_validate_output_schema_and_annotations` to reflect the corrected `required` array (the four fields above removed).
- Added `it_should_handle_issues_with_null_author_and_other_optional_fields` to directly reproduce the reported failure: a WireMock-stubbed SonarQube response with `author`, `severity`, `cleanCodeAttribute`, and `cleanCodeAttributeCategory` all absent is returned successfully without a validation error.