### PR TITLE
SONAR-27552: Add Docker publish workflow for MCP server

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,39 @@
+name: Build Docker image
+description: Build and push the SonarQube MCP server Docker image for linux/amd64 and linux/arm64
+
+inputs:
+  version:
+    description: 'MCP server version (used as MCP_SERVER_VERSION build arg)'
+    required: true
+  tags:
+    description: 'Image tags (newline-separated)'
+    required: true
+  push:
+    description: 'Push the image after build'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      with:
+        name: multibuilder
+        driver: docker-container
+        install: true
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      with:
+        platforms: all
+
+    - name: Build and push
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ inputs.push }}
+        build-args: |
+          MCP_SERVER_VERSION=${{ inputs.version }}
+        tags: ${{ inputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,9 +60,9 @@ jobs:
             VERSION=$(grep 'ARG MCP_SERVER_VERSION=' Dockerfile | cut -d= -f2)
           fi
 
-          TAGS="sonarsource/sonarqube-mcp-server:${VERSION}"
+          TAGS="sonarsource/sonarqube-mcp:${VERSION}"
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="${TAGS}"$'\n'"sonarsource/sonarqube-mcp-server:latest"
+            TAGS="${TAGS}"$'\n'"sonarsource/sonarqube-mcp:latest"
           fi
 
           if [ "${{ github.event_name }}" = "release" ] || [ "${INPUT_DRY_RUN}" = "false" ]; then

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,26 +82,10 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-        with:
-          name: multibuilder
-          driver: docker-container
-          install: true
-
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: all
-
       - name: Build and push to temporary registry
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: ./.github/actions/docker-build
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
+          version: ${{ needs.prepare.outputs.version }}
           tags: ${{ needs.prepare.outputs.temp_image }}
 
   test:
@@ -116,6 +100,7 @@ jobs:
           - platform: linux/arm64
             runner: github-ubuntu-24.04-arm-s
     runs-on: ${{ matrix.runner }}
+    permissions: {}
     steps:
       - name: Smoke test
         run: |
@@ -182,24 +167,8 @@ jobs:
           username: ${{ fromJSON(steps.secrets.outputs.vault).docker_username }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).docker_password }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-        with:
-          name: multibuilder
-          driver: docker-container
-          install: true
-
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: all
-
       - name: Build and push to Docker Hub
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: ./.github/actions/docker-build
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
+          version: ${{ needs.prepare.outputs.version }}
           tags: ${{ needs.prepare.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Publish Docker Image
 
 on:
   pull_request:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -18,6 +16,7 @@ jobs:
   prepare:
     name: Resolve build parameters
     runs-on: github-ubuntu-latest-s
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
     permissions:
       contents: read
     outputs:
@@ -34,10 +33,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "value=refs/tags/${INPUT_TAG}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "value=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=" >> "$GITHUB_OUTPUT"
+            echo "value=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository
@@ -53,22 +50,16 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${INPUT_TAG}"
-          elif [ "${{ github.event_name }}" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
-            VERSION="${TAG#v}"
           else
             VERSION=$(grep 'ARG MCP_SERVER_VERSION=' Dockerfile | cut -d= -f2)
           fi
 
-          TAGS="sonarsource/sonarqube-mcp:${VERSION}"
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="${TAGS}"$'\n'"sonarsource/sonarqube-mcp:latest"
-          fi
-
-          if [ "${{ github.event_name }}" = "release" ] || [ "${INPUT_DRY_RUN}" = "false" ]; then
+          if [ "${INPUT_DRY_RUN}" = "false" ]; then
             echo "push=true" >> "$GITHUB_OUTPUT"
+            TAGS="sonarsource/sonarqube-mcp:${VERSION}"$'\n'"sonarsource/sonarqube-mcp:latest"
           else
             echo "push=false" >> "$GITHUB_OUTPUT"
+            TAGS="sonarsource/sonarqube-mcp:${VERSION}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "temp_image=ttl.sh/sonarqube-mcp-server-${{ github.run_id }}:1h" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,21 +15,32 @@ on:
         default: true
 
 jobs:
-  publish:
-    name: Build and Push Docker Image
+  prepare:
+    name: Resolve build parameters
     runs-on: github-ubuntu-latest-s
     permissions:
-      id-token: write
       contents: read
-
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+      tags: ${{ steps.version.outputs.tags }}
+      push: ${{ steps.version.outputs.push }}
+      ref: ${{ steps.ref.outputs.value }}
     steps:
+      - name: Compute checkout ref
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=refs/tags/${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
         with:
-          ref: ${{
-            github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) ||
-            github.event_name == 'pull_request' && github.event.pull_request.head.sha ||
-            '' }}
+          ref: ${{ steps.ref.outputs.value }}
 
       - name: Resolve version
         id: version
@@ -43,11 +54,10 @@ jobs:
             VERSION=$(grep 'ARG MCP_SERVER_VERSION=' Dockerfile | cut -d= -f2)
           fi
 
+          TAGS="sonarsource/sonarqube-mcp-server:${VERSION}"
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="sonarsource/sonarqube-mcp-server:${VERSION}
+            TAGS="${TAGS}
           sonarsource/sonarqube-mcp-server:latest"
-          else
-            TAGS="sonarsource/sonarqube-mcp-server:${VERSION}"
           fi
 
           if [ "${{ github.event_name }}" = "release" ] || [ "${{ inputs.dry_run }}" = "false" ]; then
@@ -61,6 +71,84 @@ jobs:
             echo "${TAGS}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Smoke test (${{ matrix.platform }})
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: github-ubuntu-latest-s
+          - platform: linux/arm64
+            runner: github-ubuntu-24.04-arm-m
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - name: Build image
+        run: |
+          docker build \
+            --platform ${{ matrix.platform }} \
+            --build-arg MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }} \
+            --tag sonarqube-mcp-server:smoke-test \
+            .
+
+      - name: Smoke test
+        run: |
+          CONTAINER_ID=$(docker run -d -i \
+            -e SONARQUBE_IS_CLOUD=true \
+            -e SONARQUBE_URL=https://sonarcloud.io \
+            -e SONARQUBE_TOKEN=smoke-test \
+            -e TELEMETRY_DISABLED=true \
+            sonarqube-mcp-server:smoke-test)
+
+          echo "Container ID: ${CONTAINER_ID}"
+
+          SUCCESS=false
+          for i in $(seq 1 30); do
+            sleep 2
+            if docker logs "${CONTAINER_ID}" 2>&1 | grep -q 'SonarQube MCP Server Started'; then
+              SUCCESS=true
+              break
+            fi
+            if [ "$(docker inspect --format='{{.State.Status}}' "${CONTAINER_ID}" 2>/dev/null)" != "running" ]; then
+              echo "Container stopped unexpectedly"
+              break
+            fi
+          done
+
+          echo "--- Container logs ---"
+          docker logs "${CONTAINER_ID}" 2>&1
+          echo "--- End of logs ---"
+
+          docker stop "${CONTAINER_ID}" > /dev/null 2>&1 || true
+
+          if [ "${SUCCESS}" = "false" ]; then
+            echo "Smoke test FAILED: server did not log startup message within 60 seconds"
+            exit 1
+          fi
+          echo "Smoke test PASSED"
+
+  publish:
+    name: Build and push multi-platform image
+    needs: [prepare, test]
+    if: needs.prepare.outputs.push == 'true'
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - id: secrets
         name: Retrieve secrets from Vault
@@ -93,7 +181,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ steps.version.outputs.push }}
+          push: true
           build-args: |
-            MCP_SERVER_VERSION=${{ steps.version.outputs.value }}
-          tags: ${{ steps.version.outputs.tags }}
+            MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
+          tags: ${{ needs.prepare.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,99 @@
+name: Publish Docker Image
+
+on:
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version to publish (e.g. 1.18.1.2664)'
+        required: true
+      dry_run:
+        description: 'Build only, do not push to registry'
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    name: Build and Push Docker Image
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
+        with:
+          ref: ${{
+            github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) ||
+            github.event_name == 'pull_request' && github.event.pull_request.head.sha ||
+            '' }}
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION=$(grep 'ARG MCP_SERVER_VERSION=' Dockerfile | cut -d= -f2)
+          fi
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="sonarsource/sonarqube-mcp-server:${VERSION}
+          sonarsource/sonarqube-mcp-server:latest"
+          else
+            TAGS="sonarsource/sonarqube-mcp-server:${VERSION}"
+          fi
+
+          if [ "${{ github.event_name }}" = "release" ] || [ "${{ inputs.dry_run }}" = "false" ]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: secrets
+        name: Retrieve secrets from Vault
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/kv/data/docker/sonardockerrw username | docker_username;
+            development/kv/data/docker/sonardockerrw access_token_rwd | docker_password;
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ fromJSON(steps.secrets.outputs.vault).docker_username }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).docker_password }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          name: multibuilder
+          driver: docker-container
+          install: true
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: all
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.version.outputs.push }}
+          build-args: |
+            MCP_SERVER_VERSION=${{ steps.version.outputs.value }}
+          tags: ${{ steps.version.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -167,6 +167,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
       - id: secrets
         name: Retrieve secrets from Vault
         uses: SonarSource/vault-action-wrapper@v3
@@ -183,11 +188,22 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          name: multibuilder
+          driver: docker-container
+          install: true
 
-      - name: Promote to Docker Hub
-        run: |
-          TAG_ARGS=""
-          while IFS= read -r tag; do
-            [ -n "$tag" ] && TAG_ARGS="${TAG_ARGS} --tag ${tag}"
-          done <<< "${{ needs.prepare.outputs.tags }}"
-          docker buildx imagetools create ${TAG_ARGS} ${{ needs.prepare.outputs.temp_image }}
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: all
+
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
+          tags: ${{ needs.prepare.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,6 @@
 name: Publish Docker Image
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -16,7 +15,7 @@ jobs:
   prepare:
     name: Resolve build parameters
     runs-on: warp-custom-ubuntu-24-04
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     permissions:
       contents: read
     outputs:
@@ -30,13 +29,8 @@ jobs:
         id: ref
         env:
           INPUT_TAG: ${{ inputs.tag }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=refs/tags/${INPUT_TAG}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "value=refs/tags/${INPUT_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
@@ -49,11 +43,7 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${INPUT_TAG}"
-          else
-            VERSION=$(grep 'ARG MCP_SERVER_VERSION=' Dockerfile | cut -d= -f2)
-          fi
+          VERSION="${INPUT_TAG}"
 
           if [ "${INPUT_DRY_RUN}" = "false" ]; then
             echo "push=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,9 +29,11 @@ jobs:
     steps:
       - name: Compute checkout ref
         id: ref
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=refs/tags/${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "value=refs/tags/${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "value=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           else
@@ -45,9 +47,12 @@ jobs:
 
       - name: Resolve version
         id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
+            VERSION="${INPUT_TAG}"
           elif [ "${{ github.event_name }}" = "release" ]; then
             TAG="${{ github.event.release.tag_name }}"
             VERSION="${TAG#v}"
@@ -61,7 +66,7 @@ jobs:
           sonarsource/sonarqube-mcp-server:latest"
           fi
 
-          if [ "${{ github.event_name }}" = "release" ] || [ "${{ inputs.dry_run }}" = "false" ]; then
+          if [ "${{ github.event_name }}" = "release" ] || [ "${INPUT_DRY_RUN}" = "false" ]; then
             echo "push=true" >> "$GITHUB_OUTPUT"
           else
             echo "push=false" >> "$GITHUB_OUTPUT"
@@ -99,7 +104,7 @@ jobs:
           platforms: all
 
       - name: Build and push to temporary registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -174,7 +179,7 @@ jobs:
 
       - id: secrets
         name: Retrieve secrets from Vault
-        uses: SonarSource/vault-action-wrapper@v3
+        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # v3.4.0
         with:
           secrets: |
             development/kv/data/docker/sonardockerrw username | docker_username;
@@ -199,7 +204,7 @@ jobs:
           platforms: all
 
       - name: Build and push to Docker Hub
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,11 +30,12 @@ jobs:
         id: ref
         env:
           INPUT_TAG: ${{ inputs.tag }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "value=refs/tags/${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "value=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -123,7 +123,7 @@ jobs:
           - platform: linux/amd64
             runner: github-ubuntu-latest-s
           - platform: linux/arm64
-            runner: github-ubuntu-24.04-arm-m
+            runner: github-ubuntu-24.04-arm-s
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Smoke test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,7 @@ jobs:
       tags: ${{ steps.version.outputs.tags }}
       push: ${{ steps.version.outputs.push }}
       ref: ${{ steps.ref.outputs.value }}
+      temp_image: ${{ steps.version.outputs.temp_image }}
     steps:
       - name: Compute checkout ref
         id: ref
@@ -66,15 +67,50 @@ jobs:
             echo "push=false" >> "$GITHUB_OUTPUT"
           fi
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "temp_image=ttl.sh/sonarqube-mcp-server-${{ github.run_id }}:1h" >> "$GITHUB_OUTPUT"
           {
             echo "tags<<EOF"
             echo "${TAGS}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+  build:
+    name: Build multi-platform image
+    needs: prepare
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          name: multibuilder
+          driver: docker-container
+          install: true
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: all
+
+      - name: Build and push to temporary registry
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
+          tags: ${{ needs.prepare.outputs.temp_image }}
+
   test:
     name: Smoke test (${{ matrix.platform }})
-    needs: prepare
+    needs: [prepare, build]
     strategy:
       fail-fast: false
       matrix:
@@ -84,30 +120,16 @@ jobs:
           - platform: linux/arm64
             runner: github-ubuntu-24.04-arm-m
     runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
-        with:
-          ref: ${{ needs.prepare.outputs.ref }}
-
-      - name: Build image
-        run: |
-          docker build \
-            --platform ${{ matrix.platform }} \
-            --build-arg MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }} \
-            --tag sonarqube-mcp-server:smoke-test \
-            .
-
       - name: Smoke test
         run: |
           CONTAINER_ID=$(docker run -d -i \
+            --platform ${{ matrix.platform }} \
             -e SONARQUBE_IS_CLOUD=true \
             -e SONARQUBE_URL=https://sonarcloud.io \
             -e SONARQUBE_TOKEN=smoke-test \
             -e TELEMETRY_DISABLED=true \
-            sonarqube-mcp-server:smoke-test)
+            ${{ needs.prepare.outputs.temp_image }})
 
           echo "Container ID: ${CONTAINER_ID}"
 
@@ -137,7 +159,7 @@ jobs:
           echo "Smoke test PASSED"
 
   publish:
-    name: Build and push multi-platform image
+    name: Publish to Docker Hub
     needs: [prepare, test]
     if: needs.prepare.outputs.push == 'true'
     runs-on: github-ubuntu-latest-s
@@ -145,11 +167,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
-        with:
-          ref: ${{ needs.prepare.outputs.ref }}
-
       - id: secrets
         name: Retrieve secrets from Vault
         uses: SonarSource/vault-action-wrapper@v3
@@ -166,22 +183,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-        with:
-          name: multibuilder
-          driver: docker-container
-          install: true
 
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: all
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
-          tags: ${{ needs.prepare.outputs.tags }}
+      - name: Promote to Docker Hub
+        run: |
+          TAG_ARGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAG_ARGS="${TAG_ARGS} --tag ${tag}"
+          done <<< "${{ needs.prepare.outputs.tags }}"
+          docker buildx imagetools create ${TAG_ARGS} ${{ needs.prepare.outputs.temp_image }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   prepare:
     name: Resolve build parameters
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
     permissions:
       contents: read
@@ -73,7 +73,7 @@ jobs:
   build:
     name: Build multi-platform image
     needs: prepare
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       contents: read
     steps:
@@ -96,7 +96,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: github-ubuntu-latest-s
+            runner: warp-custom-ubuntu-24-04
           - platform: linux/arm64
             runner: github-ubuntu-24.04-arm-s
     runs-on: ${{ matrix.runner }}
@@ -143,7 +143,7 @@ jobs:
     name: Publish to Docker Hub
     needs: [prepare, test]
     if: needs.prepare.outputs.push == 'true'
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,11 +21,11 @@ jobs:
     permissions:
       contents: read
     outputs:
-      version: ${{ steps.version.outputs.value }}
-      tags: ${{ steps.version.outputs.tags }}
-      push: ${{ steps.version.outputs.push }}
+      version: ${{ steps.params.outputs.version }}
+      tags: ${{ steps.params.outputs.tags }}
+      push: ${{ steps.params.outputs.push }}
       ref: ${{ steps.ref.outputs.value }}
-      temp_image: ${{ steps.version.outputs.temp_image }}
+      temp_image: ${{ steps.params.outputs.temp_image }}
     steps:
       - name: Compute checkout ref
         id: ref
@@ -45,8 +45,8 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.value }}
 
-      - name: Resolve version
-        id: version
+      - name: Compute build parameters
+        id: params
         env:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
@@ -62,8 +62,7 @@ jobs:
 
           TAGS="sonarsource/sonarqube-mcp-server:${VERSION}"
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="${TAGS}
-          sonarsource/sonarqube-mcp-server:latest"
+            TAGS="${TAGS}"$'\n'"sonarsource/sonarqube-mcp-server:latest"
           fi
 
           if [ "${{ github.event_name }}" = "release" ] || [ "${INPUT_DRY_RUN}" = "false" ]; then
@@ -71,7 +70,7 @@ jobs:
           else
             echo "push=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "temp_image=ttl.sh/sonarqube-mcp-server-${{ github.run_id }}:1h" >> "$GITHUB_OUTPUT"
           {
             echo "tags<<EOF"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk update &&  \
 
 WORKDIR /app
 
-ADD https://binaries.sonarsource.com/Distribution/sonarqube-mcp-server/sonarqube-mcp-server-1.18.1.2664.jar ./sonarqube-mcp-server.jar
+ARG MCP_SERVER_VERSION=1.18.1.2664
+ADD https://binaries.sonarsource.com/Distribution/sonarqube-mcp-server/sonarqube-mcp-server-${MCP_SERVER_VERSION}.jar ./sonarqube-mcp-server.jar
 
 RUN jdeps --ignore-missing-deps -q  \
     --recursive  \


### PR DESCRIPTION
## SONAR-27552: Add Docker publish workflow for MCP server

Introduces a CI workflow to build and publish the MCP server Docker image to [sonarsource/sonarqube-mcp](https://hub.docker.com/r/sonarsource/sonarqube-mcp) on Docker Hub.

## Changes

**`Dockerfile`**
- Parameterized the JAR download URL via `ARG MCP_SERVER_VERSION` (default `1.18.1.2664` preserved for local builds and PR dry runs).

**`.github/workflows/docker-publish.yml`** (new)
- `release` trigger: builds and pushes `<version>` + `latest` tags automatically when a release is published.
- `workflow_dispatch` trigger: on-demand publish with a required `tag` input; checks out the exact git tag snapshot. A `dry_run` boolean (default: `true`) allows build validation without pushing.
- `pull_request` trigger: dry-run only (never pushes), checks out the PR head SHA, and reads the version from the Dockerfile `ARG` default.
- Multi-platform build (linux/amd64 + linux/arm64) via QEMU and Docker Buildx with the `docker-container` driver.
- Smoke test: starts the container with `SONARQUBE_IS_CLOUD=true` and waits for `SonarQube MCP Server Started` in the logs; runs on each platform's native runner using a shared temp image from [ttl.sh](https://ttl.sh).
- Docker Hub credentials retrieved from Vault (`development/kv/data/docker/sonardockerrw`).
- User-controlled inputs (`inputs.tag`, `inputs.dry_run`) are assigned to environment variables before being used in shell scripts to prevent script injection.

## Workflow design

```
prepare  →  build (multi-platform → ttl.sh)  →  test (amd64 + arm64, native runners)  →  publish (rebuild → Docker Hub)
```

The publish job rebuilds the image instead of promoting the temp image to avoid any provenance metadata referencing the ttl.sh registry.