### PR TITLE
[codex] Update Copilot MCP Docker env examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,14 +245,14 @@ In your GitHub repository, navigate under **Settings -> Copilot -> Coding agent*
         "--rm",
         "-i",
         "-e",
-        "SONARQUBE_TOKEN=$SONAR_TOKEN",
+        "SONARQUBE_TOKEN",
         "-e",
-        "SONARQUBE_ORG=$SONAR_ORG",
+        "SONARQUBE_ORG",
         "mcp/sonarqube"
       ],
       "env": {
-        "SONAR_TOKEN": "COPILOT_MCP_SONARQUBE_TOKEN",
-        "SONAR_ORG": "COPILOT_MCP_SONARQUBE_ORG"
+        "SONARQUBE_TOKEN": "COPILOT_MCP_SONARQUBE_TOKEN",
+        "SONARQUBE_ORG": "COPILOT_MCP_SONARQUBE_ORG"
       },
       "tools": ["*"]
     }
@@ -260,7 +260,7 @@ In your GitHub repository, navigate under **Settings -> Copilot -> Coding agent*
 }
 ```
 
-For **SonarQube Cloud US**, add `"-e", "SONARQUBE_URL=$SONAR_URL"` to the `args` array and `"SONAR_URL": "COPILOT_MCP_SONARQUBE_URL"` to the `env` section, then set the secret `COPILOT_MCP_SONARQUBE_URL=https://sonarqube.us`.
+For **SonarQube Cloud US**, add `"-e", "SONARQUBE_URL"` to the `args` array and `"SONARQUBE_URL": "COPILOT_MCP_SONARQUBE_URL"` to the `env` section, then set the secret `COPILOT_MCP_SONARQUBE_URL=https://sonarqube.us`.
 
 * To connect with SonarQube Server:
 
@@ -277,14 +277,14 @@ For **SonarQube Cloud US**, add `"-e", "SONARQUBE_URL=$SONAR_URL"` to the `args`
         "--rm",
         "-i",
         "-e",
-        "SONARQUBE_TOKEN=$SONAR_TOKEN",
+        "SONARQUBE_TOKEN",
         "-e",
-        "SONARQUBE_URL=$SONAR_URL",
+        "SONARQUBE_URL",
         "mcp/sonarqube"
       ],
       "env": {
-        "SONAR_TOKEN": "COPILOT_MCP_SONARQUBE_USER_TOKEN",
-        "SONAR_URL": "COPILOT_MCP_SONARQUBE_URL"
+        "SONARQUBE_TOKEN": "COPILOT_MCP_SONARQUBE_USER_TOKEN",
+        "SONARQUBE_URL": "COPILOT_MCP_SONARQUBE_URL"
       },
       "tools": ["*"]
     }


### PR DESCRIPTION
## Summary

Update the GitHub Copilot coding agent README examples so Docker receives the latest mcp/sonarqube environment variable names directly.

## Why

The previous examples mapped Copilot secrets to intermediate names like SONAR_TOKEN and then used Docker arguments such as SONARQUBE_TOKEN=. The current Docker examples elsewhere in the README use pass-through variables, for example -e SONARQUBE_TOKEN, with the MCP environment mapping providing the value.

## Impact

Users configuring SonarQube Cloud or SonarQube Server for the GitHub Copilot coding agent can copy the examples without manually correcting SONARQUBE_TOKEN, SONARQUBE_ORG, or SONARQUBE_URL handling.

## Validation

- Reviewed git diff -- README.md
- Searched README for remaining Docker SONARQUBE_*=$... argument patterns; remaining $... references are Claude CLI --env examples only