### PR TITLE
Treat blank optional string arguments as absent

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
@@ -134,7 +134,7 @@ public abstract class Tool {
     public String getOptionalString(String argumentName) {
       var arg = argumentsMap.get(argumentName);
       if (arg instanceof String string) {
-        return string;
+        return string.isBlank() ? null : string;
       } else {
         return null;
       }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolArgumentsTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolArgumentsTest.java
@@ -180,6 +180,15 @@ class ToolArgumentsTest {
   }
 
   @Test
+  void should_return_null_when_optional_string_argument_is_blank() {
+    var arguments = new Tool.Arguments(Map.of("blankArg", " "), null);
+
+    var result = arguments.getOptionalString("blankArg");
+
+    assertThat(result).isNull();
+  }
+
+  @Test
   void should_return_value_when_int_or_default_argument_is_present() {
     var arguments = new Tool.Arguments(Map.of("intArg", 42), null);
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsToolTests.java
@@ -496,6 +496,61 @@ class SearchSecurityHotspotsToolTests {
           }
         }""");
     }
+
+    @SonarQubeMcpServerTest
+    void it_should_ignore_blank_pull_request(SonarQubeMcpServerTestHarness harness) {
+      var hotspotKey = "AXJMFm6ERa2AinNL_0fP";
+      harness.getMockSonarQubeServer().stubFor(get(HotspotsApi.SEARCH_PATH + "?projectKey=my-project")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes("""
+            {
+                "paging": {
+                  "pageIndex": 1,
+                  "pageSize": 100,
+                  "total": 1
+                },
+                "hotspots": [%s],
+                "components": []
+              }
+            """.formatted(generateHotspot(hotspotKey)).getBytes(StandardCharsets.UTF_8)))));
+      var mcpClient = harness.newClient();
+
+      var result = mcpClient.callTool(
+        SearchSecurityHotspotsTool.TOOL_NAME,
+        Map.of(
+          SearchSecurityHotspotsTool.PROJECT_KEY_PROPERTY, "my-project",
+          SearchSecurityHotspotsTool.PULL_REQUEST_PROPERTY, ""));
+
+      assertResultEquals(result, """
+        {
+          "hotspots" : [ {
+            "key" : "AXJMFm6ERa2AinNL_0fP",
+            "component" : "com.example:project:src/main/java/com/example/Service.java",
+            "project" : "com.example:project",
+            "securityCategory" : "sql-injection",
+            "vulnerabilityProbability" : "HIGH",
+            "status" : "TO_REVIEW",
+            "line" : 42,
+            "message" : "Make sure using this hardcoded IP address is safe here.",
+            "assignee" : "john.doe",
+            "author" : "jane.smith",
+            "creationDate" : "2023-05-13T17:55:39+0200",
+            "updateDate" : "2023-05-14T10:20:15+0200",
+            "textRange" : {
+              "startLine" : 42,
+              "endLine" : 42,
+              "startOffset" : 15,
+              "endOffset" : 30
+            },
+            "ruleKey" : "java:S1313"
+          } ],
+          "paging" : {
+            "pageIndex" : 1,
+            "pageSize" : 100,
+            "total" : 1
+          }
+        }""");
+    }
   }
 
   private static String generateHotspot(String hotspotKey) {


### PR DESCRIPTION
Make getOptionalString return null for blank strings so that optional parameters with empty/whitespace-only values are treated the same as unset parameters.

This fixes an issue where invoking tools such as `search_security_hotspots` on a local project without a pull request ID fails, because the SonarQube Server's endpoint rejects a URL with an empty `pullRequest` parameter.

It's reproducible with OpenCode, using either a Docker or jar version of the project.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

* Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube-mcp-server/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/MCP) ticket available, please make your commits and pull request start with the ticket ID (MCP-XXXX)
