### PR TITLE
Fix analyze_code_snippet silently returning 0 issues for .tsx/.jsx files

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -53,7 +53,7 @@ The user should provide the following environment variables:
 - Python (including IPython notebooks)
 - Ruby
 - Go
-- JavaScript, TypeScript, JSP
+- JavaScript (js, jsx), TypeScript (ts, tsx), JSP
 - PHP
 - XML
 - HTML, CSS

--- a/README.md
+++ b/README.md
@@ -901,10 +901,10 @@ SOCKS5 proxies are supported.
   - `filePath` - Project-relative path of the file to analyze (e.g., `src/main/java/MyClass.java`). Used when the workspace is mounted at `/app/mcp-workspace` - _String_
   - `fileContent` - Complete file content as a string. Required when workspace is not mounted - _String_
   - `codeSnippet` - Code snippet to filter issues (must match content in fileContent) - _String_
-  - `language` - Language of the code (e.g., 'java', 'python', 'javascript') - _String_
+  - `language` - Language of the code (e.g., 'java', 'python', 'js', 'ts', 'tsx', 'jsx') - _String_
   - `scope` - Scope of the file: MAIN or TEST (default: MAIN) - _String_
   
-  **Supported Languages:** Java, Kotlin, Python, Ruby, Go, JavaScript, TypeScript, JSP, PHP, XML, HTML, CSS, CloudFormation, Kubernetes, Terraform, Azure Resource Manager, Ansible, Docker, Secrets detection
+  **Supported Languages:** Java, Kotlin, Python, Ruby, Go, JavaScript (`js`, `jsx`), TypeScript (`ts`, `tsx`), JSP, PHP, XML, HTML, CSS, CloudFormation, Kubernetes, Terraform, Azure Resource Manager, Ansible, Docker, Secrets detection
 
 **When integration with SonarQube for IDE is enabled:**
 - **analyze_file_list** - Analyze files in the current working directory using SonarQube for IDE. This tool connects to a running SonarQube for IDE instance to perform code quality analysis on a list of files.

--- a/src/main/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtils.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtils.java
@@ -16,13 +16,14 @@
  */
 package org.sonarsource.sonarqube.mcp.analysis;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
@@ -78,15 +79,16 @@ public class LanguageUtils {
   }
 
   public static String[] getValidLanguageNames() {
-    var names = new ArrayList<>(SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.values().stream()
-      .flatMap(Set::stream)
-      .map(Language::name)
-      .map(String::toLowerCase)
+    return Stream.concat(
+      SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.values().stream()
+        .flatMap(Set::stream)
+        .map(Language::name)
+        .map(s -> s.toLowerCase(Locale.ROOT)),
+      JSX_LANGUAGE_ALIASES.keySet().stream()
+    )
       .distinct()
       .sorted()
-      .toList());
-    names.addAll(JSX_LANGUAGE_ALIASES.keySet().stream().sorted().toList());
-    return names.toArray(String[]::new);
+      .toArray(String[]::new);
   }
 
   @Nullable
@@ -95,7 +97,7 @@ public class LanguageUtils {
       return null;
     }
 
-    var alias = JSX_LANGUAGE_ALIASES.get(languageInput.toLowerCase());
+    var alias = JSX_LANGUAGE_ALIASES.get(languageInput.toLowerCase(Locale.ROOT));
     if (alias != null) {
       return alias;
     }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtils.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtils.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.sonarqube.mcp.analysis;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,20 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 public class LanguageUtils {
 
   public static final Map<String, Set<Language>> SUPPORTED_LANGUAGES_BY_PLUGIN_KEY = new HashMap<>();
+
+  /**
+   * Aliases for JSX/TSX: these are not distinct SonarLanguage values, but require a different
+   * file extension so the TS/JS analyzer enables JSX parsing (it does so only for .tsx/.jsx files).
+   */
+  public static final Map<String, SonarLanguage> JSX_LANGUAGE_ALIASES = Map.of(
+    "tsx", SonarLanguage.TS,
+    "jsx", SonarLanguage.JS
+  );
+
+  public static final Map<String, String> JSX_FILE_EXTENSIONS = Map.of(
+    "tsx", ".tsx",
+    "jsx", ".jsx"
+  );
 
   static {
     SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.put("kotlin", Set.of(Language.KOTLIN));
@@ -63,19 +78,26 @@ public class LanguageUtils {
   }
 
   public static String[] getValidLanguageNames() {
-    return SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.values().stream()
+    var names = new ArrayList<>(SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.values().stream()
       .flatMap(Set::stream)
       .map(Language::name)
       .map(String::toLowerCase)
       .distinct()
       .sorted()
-      .toArray(String[]::new);
+      .toList());
+    names.addAll(JSX_LANGUAGE_ALIASES.keySet().stream().sorted().toList());
+    return names.toArray(String[]::new);
   }
 
   @Nullable
   public static SonarLanguage getSonarLanguageFromInput(@Nullable String languageInput) {
     if (languageInput == null) {
       return null;
+    }
+
+    var alias = JSX_LANGUAGE_ALIASES.get(languageInput.toLowerCase());
+    if (alias != null) {
+      return alias;
     }
 
     for (var sonarLanguage : getSupportedSonarLanguages()) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -224,7 +225,7 @@ public class AnalyzeCodeSnippetTool extends Tool {
 
   private static Path createTemporaryFileForLanguage(String analysisId, Path workDir, String fileContent,
     SonarLanguage language, @Nullable String languageInput) throws IOException {
-    var extension = languageInput != null ? JSX_FILE_EXTENSIONS.get(languageInput.toLowerCase()) : null;
+    var extension = languageInput != null ? JSX_FILE_EXTENSIONS.get(languageInput.toLowerCase(Locale.ROOT)) : null;
     if (extension == null) {
       var defaultFileSuffixes = language.getDefaultFileSuffixes();
       extension = defaultFileSuffixes.length > 0 ? defaultFileSuffixes[0] : ".txt";

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
@@ -40,6 +40,7 @@ import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
 
 import static java.util.stream.Collectors.toMap;
+import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.JSX_FILE_EXTENSIONS;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.getSonarLanguageFromInput;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.getValidLanguageNames;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.mapSonarLanguageToLanguage;
@@ -179,7 +180,7 @@ public class AnalyzeCodeSnippetTool extends Tool {
     Path tmpFile = null;
     try {
       tmpFile = createTemporaryFileForLanguage(analysisId.toString(), backendService.getWorkDir(), fileContent,
-        sonarLanguage);
+        sonarLanguage, language);
       var clientFileDto = backendService.toClientFileDto(tmpFile, fileContent, mapSonarLanguageToLanguage(sonarLanguage), isTest);
       backendService.addFile(clientFileDto);
       var response = backendService.analyzeFilesAndTrack(analysisId, List.of(tmpFile.toUri())).get(30, TimeUnit.SECONDS);
@@ -221,11 +222,12 @@ public class AnalyzeCodeSnippetTool extends Tool {
     backendService.updateRulesConfiguration(activeRules);
   }
 
-  private static Path createTemporaryFileForLanguage(String analysisId, Path workDir, String fileContent, SonarLanguage language) throws IOException {
-    var defaultFileSuffixes = language.getDefaultFileSuffixes();
-    var extension = defaultFileSuffixes.length > 0 ? defaultFileSuffixes[0] : "";
-    if (extension.isBlank()) {
-      extension = ".txt";
+  private static Path createTemporaryFileForLanguage(String analysisId, Path workDir, String fileContent,
+    SonarLanguage language, @Nullable String languageInput) throws IOException {
+    var extension = languageInput != null ? JSX_FILE_EXTENSIONS.get(languageInput.toLowerCase()) : null;
+    if (extension == null) {
+      var defaultFileSuffixes = language.getDefaultFileSuffixes();
+      extension = defaultFileSuffixes.length > 0 ? defaultFileSuffixes[0] : ".txt";
     }
     var tempFile = workDir.resolve("analysis-" + analysisId + extension);
     Files.writeString(tempFile, fileContent);

--- a/src/test/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtilsTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtilsTests.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.sonarqube.mcp.analysis;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
@@ -50,6 +51,83 @@ class LanguageUtilsTests {
     var result = LanguageUtils.mapSonarLanguageToLanguage(SonarLanguage.JAVA);
 
     assertThat(result).isEqualTo(Language.JAVA);
+  }
+
+  // --- tsx/jsx alias resolution ---
+
+  @Test
+  void should_resolve_tsx_alias_to_ts_sonar_language() {
+    assertThat(LanguageUtils.getSonarLanguageFromInput("tsx")).isEqualTo(SonarLanguage.TS);
+  }
+
+  @Test
+  void should_resolve_jsx_alias_to_js_sonar_language() {
+    assertThat(LanguageUtils.getSonarLanguageFromInput("jsx")).isEqualTo(SonarLanguage.JS);
+  }
+
+  @Test
+  void should_resolve_tsx_alias_case_insensitively() {
+    assertThat(LanguageUtils.getSonarLanguageFromInput("TSX")).isEqualTo(SonarLanguage.TS);
+    assertThat(LanguageUtils.getSonarLanguageFromInput("Tsx")).isEqualTo(SonarLanguage.TS);
+  }
+
+  @Test
+  void should_resolve_jsx_alias_case_insensitively() {
+    assertThat(LanguageUtils.getSonarLanguageFromInput("JSX")).isEqualTo(SonarLanguage.JS);
+    assertThat(LanguageUtils.getSonarLanguageFromInput("Jsx")).isEqualTo(SonarLanguage.JS);
+  }
+
+  // --- regression: existing ts/js behaviour unchanged ---
+
+  @Test
+  void should_still_resolve_ts_to_ts_sonar_language() {
+    assertThat(LanguageUtils.getSonarLanguageFromInput("ts")).isEqualTo(SonarLanguage.TS);
+  }
+
+  @Test
+  void should_still_resolve_js_to_js_sonar_language() {
+    assertThat(LanguageUtils.getSonarLanguageFromInput("js")).isEqualTo(SonarLanguage.JS);
+  }
+
+  // --- valid language names ---
+
+  @Test
+  void should_include_tsx_and_jsx_in_valid_language_names() {
+    var names = Arrays.asList(LanguageUtils.getValidLanguageNames());
+
+    assertThat(names).contains("tsx", "jsx");
+  }
+
+  @Test
+  void should_not_duplicate_existing_languages_when_tsx_and_jsx_are_added() {
+    var names = Arrays.asList(LanguageUtils.getValidLanguageNames());
+
+    assertThat(names.stream().filter("ts"::equals).count()).isEqualTo(1);
+    assertThat(names.stream().filter("js"::equals).count()).isEqualTo(1);
+    assertThat(names.stream().filter("tsx"::equals).count()).isEqualTo(1);
+    assertThat(names.stream().filter("jsx"::equals).count()).isEqualTo(1);
+  }
+
+  // --- file extension overrides ---
+
+  @Test
+  void should_map_tsx_to_tsx_file_extension() {
+    assertThat(LanguageUtils.JSX_FILE_EXTENSIONS.get("tsx")).isEqualTo(".tsx");
+  }
+
+  @Test
+  void should_map_jsx_to_jsx_file_extension() {
+    assertThat(LanguageUtils.JSX_FILE_EXTENSIONS.get("jsx")).isEqualTo(".jsx");
+  }
+
+  @Test
+  void should_not_override_extension_for_plain_ts() {
+    assertThat(LanguageUtils.JSX_FILE_EXTENSIONS.get("ts")).isNull();
+  }
+
+  @Test
+  void should_not_override_extension_for_plain_js() {
+    assertThat(LanguageUtils.JSX_FILE_EXTENSIONS.get("js")).isNull();
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
@@ -479,6 +479,34 @@ class AnalyzeCodeSnippetToolTests {
     }
 
     @SonarQubeMcpServerTest
+    void it_should_accept_tsx_as_a_valid_language(SonarQubeMcpServerTestHarness harness) {
+      mockServerRules(harness, null, List.of());
+      var mcpClient = harness.withPlugins().newClient();
+
+      var result = mcpClient.callTool(
+        TOOL_NAME,
+        Map.of(
+          AnalyzeCodeSnippetTool.FILE_CONTENT_PROPERTY, "const C = () => <div>hello</div>;",
+          AnalyzeCodeSnippetTool.LANGUAGE_PROPERTY, "tsx"));
+
+      assertThat(result.isError()).isFalse();
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_accept_jsx_as_a_valid_language(SonarQubeMcpServerTestHarness harness) {
+      mockServerRules(harness, null, List.of());
+      var mcpClient = harness.withPlugins().newClient();
+
+      var result = mcpClient.callTool(
+        TOOL_NAME,
+        Map.of(
+          AnalyzeCodeSnippetTool.FILE_CONTENT_PROPERTY, "const C = () => <div>hello</div>;",
+          AnalyzeCodeSnippetTool.LANGUAGE_PROPERTY, "jsx"));
+
+      assertThat(result.isError()).isFalse();
+    }
+
+    @SonarQubeMcpServerTest
     void it_should_return_error_when_file_path_is_missing(SonarQubeMcpServerTestHarness harness) throws IOException {
       mockServerRules(harness, null, List.of("php:S1135"));
       var workspaceDir = Files.createTempDirectory("sonar-mcp-workspace");


### PR DESCRIPTION
Fixes #396

## Problem

`analyze_code_snippet` silently returns `{"issues":[],"issueCount":0}` when analyzing TSX/JSX content. The root cause is a two-step failure:

1. The `language` enum only exposes `ts` and `js` — there is no `tsx` or `jsx`.
2. When a user passes `language: "ts"` for TSX content, `createTemporaryFileForLanguage` creates a temp file with a `.ts` extension (derived from `SonarLanguage.TS.getDefaultFileSuffixes()`). The TypeScript analyzer **only enables JSX parsing for `.tsx` files** — for `.ts` files it silently bails on JSX syntax and reports zero issues, with no error or diagnostic.

Every `.tsx`/`.jsx` file in React/Next.js codebases gets a false-clean result. Agents trust it and report the file as clean.

## Fix

- Add `tsx` and `jsx` as accepted language aliases in `LanguageUtils`, mapping:
  - `tsx` → `SonarLanguage.TS` + `.tsx` temp file extension
  - `jsx` → `SonarLanguage.JS` + `.jsx` temp file extension
- When the user passes `language: "tsx"` or `language: "jsx"`, the temp file is created with the correct extension so the TS/JS analyzer enables JSX parsing
- The existing `ts` and `js` behaviour is unchanged

## Checklist

- [x] Explain motives: bug causes false-clean results on all TSX/JSX files in agentic workflows (described above and in #396)
- [x] Code style follows [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests provided for all changed code (12 new tests in `LanguageUtilsTests`, including alias resolution, case-insensitivity, no-duplicate, extension mapping, and regression tests for existing `ts`/`js` behaviour)
- [x] Integration tests provided (`it_should_accept_tsx_as_a_valid_language`, `it_should_accept_jsx_as_a_valid_language` — server logs confirm `.tsx`/`.jsx` temp files are created)
- [ ] No JIRA ticket available (referencing GitHub issue #396)