### PR TITLE
DEX-50 Stop accepting external PR contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report something that isn't working as expected in the SonarQube MCP Server.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the fields below so we can reproduce and triage it quickly.
+  - type: input
+    id: version
+    attributes:
+      label: SonarQube MCP Server version
+      description: The image tag or release version you're running.
+      placeholder: e.g. 1.2.0
+    validations:
+      required: true
+  - type: dropdown
+    id: run-mode
+    attributes:
+      label: How are you running the server?
+      options:
+        - Docker image
+        - Standalone JAR
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: client
+    attributes:
+      label: MCP client / agent
+      description: Which client connects to the server?
+      placeholder: e.g. Claude Desktop, Claude Code, Cursor, VS Code
+    validations:
+      required: true
+  - type: dropdown
+    id: backend
+    attributes:
+      label: SonarQube backend
+      options:
+        - SonarQube Cloud
+        - SonarQube Server
+        - SonarQube Community Build
+        - Not applicable / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: The error or unexpected behavior, including server logs (redact tokens and other secrets).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we trigger this? Include relevant configuration (with secrets redacted).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  # GitHub automatically adds a "Report a security vulnerability" link here because
+  # SECURITY.md exists, so we intentionally don't duplicate it in this file.
+  - name: General SonarQube product questions
+    url: https://community.sonarsource.com/
+    about: For questions not specific to the MCP server, ask the SonarSource Community forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an idea or improvement for the SonarQube MCP Server.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! We can't promise every idea ships, but describing the problem clearly helps us plan and prioritize.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what's getting in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like the MCP server to do? New tool, new option, different behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've tried or thought about.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,15 @@
+name: Question / feedback
+description: Ask a question about the SonarQube MCP Server or share general feedback.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about the MCP server, or feedback that isn't a bug or a feature request? Tell us here.
+
+        For general SonarQube product questions not specific to the MCP server, the [Community forum](https://community.sonarsource.com/) is usually the faster path.
+  - type: textarea
+    id: details
+    attributes:
+      label: Your question or feedback
+    validations:
+      required: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,13 +1,10 @@
 Contributing
 ============
 
-If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).
+We don't accept external pull requests on this project. This isn't about the quality of your change — keeping every change flowing through one place lets us properly track, plan, prioritize, and test what goes into the SonarQube MCP Server.
 
-Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside
-Sonar to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes.
+That doesn't mean we don't want to hear from you — we do. If you've hit a bug or have an idea, please [open a GitHub Issue](https://github.com/SonarSource/sonarqube-mcp-server/issues/new/choose) and we'll take it from there. That's where we now track and prioritize bugs and feature requests.
 
-With that in mind, if you would like to submit a code contribution, please create a pull request for this repository. Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make.
-
-Make sure that you follow our [code style](https://github.com/SonarSource/sonar-developer-toolset#code-style) and all tests are passing.
+The source is public, so you're always welcome to fork it, read it, and experiment.
 
 Thank You! The Sonar Team


### PR DESCRIPTION
- docs/contributing.md: no external PRs, redirect to GitHub Issues (was: forum for features); fork-and-experiment kept
- Add structured issue forms (bug/feature/question) with no auto-labels (manual triage signal)
- config.yml: blank issues disabled, forum link for general questions; SECURITY.md is surfaced automatically by GitHub, so no security link here

External PRs are handled manually by the team (comment + close); GitHub's fork-PR approval gate already prevents untrusted CI from running unattended.