### PR TITLE
MCP-485 Fix release notes automation

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -140,6 +140,7 @@ jobs:
       - name: Copy draft body to published release and delete draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           DRAFT_VERSION: ${{ needs.check-draft-exists.outputs.release-version }}
           RELEASED_VERSION: ${{ needs.release.outputs.released-version }}
         run: |


### PR DESCRIPTION
gh release needs a repo context; without actions/checkout, it tries to use the local git remote and fails with fatal: not a git repository.

----
## Summary by Gitar

- **Workflow configuration:**
  - Added `GH_REPO` environment variable to the `full-release.yml` workflow to ensure correct release note automation.

<sub>This will update automatically on new commits.</sub>