### PR TITLE
MCP-401 Reintroduce the branch parameter

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -90,9 +90,11 @@ Always resolve the project key using the following lookup order — **never gues
 - Note: Secrets detection works on all file types regardless of language
 
 ### Branch and Pull Request Context
-- Many operations support branch-specific analysis
-- If user mentions working on a feature branch, include the branch parameter
-- Pull request analysis is available for PR-specific insights
+- **Long-lived branches** (main, develop, release/*): use the `branch` parameter. Discover valid names with `list_branches`.
+- **Pull requests / feature branches**: use `pullRequest`. Discover PR keys with `list_pull_requests`.
+- Never pass a git branch name to a `pullRequest` parameter — it expects the SonarQube PR key.
+- Never provide both `branch` and `pullRequest` on the same call.
+- Omit both to query the default (main) branch analysis.
 
 ### Code Issues and Violations
 - After fixing issues, do not attempt to verify them using `search_sonar_issues_in_projects`, as the server will not yet reflect the updates

--- a/README.md
+++ b/README.md
@@ -928,7 +928,8 @@ SOCKS5 proxies are supported.
 
 - **search_files_by_coverage** - Search for files in a project sorted by coverage (ascending - worst coverage first). This tool helps identify files that need test coverage improvements.
   - `projectKey` - The project key to search in - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `pullRequest` - Pull request id to analyze - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `maxCoverage` - Maximum coverage threshold (0-100). Only return files with coverage <= this value - _Number_
   - `pageIndex` - Page index (1-based, default: 1) - _Number_
   - `pageSize` - Page size (default: 100, max: 500) - _Number_
@@ -936,7 +937,8 @@ SOCKS5 proxies are supported.
 
 - **get_file_coverage_details** - Get line-by-line coverage information for a specific file, including which exact lines are uncovered and which have partially covered branches. This tool helps identify precisely where to add test coverage. Use after identifying files with low coverage via search_files_by_coverage.
   - `key` - File key (e.g. my_project:src/foo/Bar.java) - _Required String_
-  - `pullRequest` - Pull request id - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `from` - First line to analyze (1-based, default: 1) - _Number_
   - `to` - Last line to analyze (inclusive). If not specified, all lines are returned - _Number_
 
@@ -946,8 +948,8 @@ SOCKS5 proxies are supported.
 
 - **search_dependency_risks** - Search for software composition analysis issues (dependency risks) of a SonarQube project, paired with releases that appear in the analyzed project, application, or portfolio.
   - `projectKey` - Project key - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `branchKey` - Optional branch key - _String_
-  - `pullRequestKey` - Optional pull request key - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `pageIndex` - Optional page index (1-based, default: 1) - _Integer_
   - `pageSize` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
 
@@ -967,7 +969,8 @@ SOCKS5 proxies are supported.
 
 - **search_sonar_issues_in_projects** - Search for SonarQube issues in my organization's projects.
   - `projects` - Optional list of Sonar projects - _String[]_
-  - `pullRequestId` - Optional Pull Request's identifier - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `severities` - Optional list of severities to filter by. Possible values: INFO, LOW, MEDIUM, HIGH, BLOCKER - _String[]_
   - `impactSoftwareQualities` - Optional list of software qualities to filter by. Possible values: MAINTAINABILITY, RELIABILITY, SECURITY - _String[]_
   - `issueStatuses` - Optional list of issue statuses to filter by. Possible values: OPEN, CONFIRMED, FALSE_POSITIVE, ACCEPTED, FIXED, IN_SANDBOX - _String[]_
@@ -980,8 +983,8 @@ SOCKS5 proxies are supported.
 - **search_security_hotspots** - Search for Security Hotspots in a SonarQube project.
   - `projectKey` - Project or application key - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
   - `hotspotKeys` - Comma-separated list of specific Security Hotspot keys to retrieve - _String[]_
-  - `branch` - Optional branch key - _String_
-  - `pullRequest` - Optional pull request key - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `files` - Optional list of file paths to filter - _String[]_
   - `status` - Optional status filter: TO_REVIEW, REVIEWED - _String_
   - `resolution` - Optional resolution filter: FIXED, SAFE, ACKNOWLEDGED - _String_
@@ -1010,8 +1013,9 @@ SOCKS5 proxies are supported.
 
 - **get_component_measures** - Get SonarQube measures for a component (project, directory, file).
   - `projectKey` - The project key - _Required String when `SONARQUBE_PROJECT_KEY` is not configured_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
   - `metricKeys` - Optional metric keys to retrieve (e.g. ncloc, complexity, violations, coverage) - _String[]_
-  - `pullRequest` - Optional pull request identifier to analyze for measures - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
 ### Metrics
 
@@ -1043,16 +1047,21 @@ SOCKS5 proxies are supported.
   - `page` - Optional page number - _String_
 
 
-- **list_pull_requests** - List all pull requests for a project. Use this tool to discover available pull requests before analyzing their coverage, issues, or quality. Returns the pull request key/ID which can be used with other tools (e.g., search_files_by_coverage, get_file_coverage_details).
+- **list_branches** - List branches for a project. Use returned branch names as the `branch` parameter on other tools. For pull requests, use `list_pull_requests` instead.
+  - `projectKey` - Project key (e.g. my_project) - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
+
+
+- **list_pull_requests** - List all pull requests for a project. Use this tool to discover available pull requests before analyzing their coverage, issues, or quality. Returns the pull request key/ID which can be used with other tools (e.g., search_files_by_coverage, get_file_coverage_details). For long-lived branches, use `list_branches` instead.
   - `projectKey` - Project key (e.g. my_project) - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
 
 ### Quality Gates
 
 - **get_project_quality_gate_status** - Get the Quality Gate Status for the SonarQube project.
   - `analysisId` - Optional analysis ID - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
   - `projectId` - Optional project ID - _String_
   - `projectKey` - Optional project key - _String_
-  - `pullRequest` - Optional pull request ID - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
 
 - **list_quality_gates** - List all quality gates in my SonarQube.
@@ -1066,20 +1075,23 @@ SOCKS5 proxies are supported.
 
 - **search_duplicated_files** - Search for files with code duplications in a SonarQube project. By default, automatically fetches all duplicated files across all pages (up to 10,000 files max). Returns only files with duplications.
   - `projectKey` - Project key - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `pullRequest` - Optional pull request id - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `pageSize` - Optional number of results per page for manual pagination (max: 500). If not specified, auto-fetches all duplicated files - _Integer_
   - `pageIndex` - Optional page number for manual pagination (starts at 1). If not specified, auto-fetches all duplicated files - _Integer_
 
 
 - **get_duplications** - Get duplications for a file. Require Browse permission on file's project.
   - `key` - File key - _Required String_
-  - `pullRequest` - Optional pull request id - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
 ### Sources
 
 - **get_raw_source** - Get source code as raw text from SonarQube. Require 'See Source Code' permission on file.
   - `key` - File key - _Required String_
-  - `pullRequest` - Optional pull request id - _String_
+  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
 
 - **get_scm_info** - Get SCM information of SonarQube source files. Require See Source Code permission on file's project.

--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ SOCKS5 proxies are supported.
   - `page` - Optional page number - _String_
 
 
-- **list_branches** - List branches for a project. Use returned branch names as the `branch` parameter on other tools. For pull requests, use `list_pull_requests` instead.
+- **list_branches** - List long-lived branches for a project (e.g. main, develop, master). Returns only `LONG` branches on SonarQube Cloud and `BRANCH` entries on SonarQube Server — names safe for the `branch` parameter on other tools. For pull requests, use `list_pull_requests` instead.
   - `projectKey` - Project key (e.g. my_project) - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
 
 

--- a/agent_configurations/kiro_power/POWER.md
+++ b/agent_configurations/kiro_power/POWER.md
@@ -106,17 +106,28 @@ search_sonar_issues_in_projects({
     ps: 100
 });
 
-// Filter by issue status
+// Filter by issue status on a long-lived branch
 search_sonar_issues_in_projects({
     projects: ["my-project"],
     issueStatuses: ["OPEN", "CONFIRMED"],
     branch: "main"
 });
+```
 
-// Get a specific issue by key
-search_sonar_issues_in_projects({
-    issueKey: "AYz123abc"
-});
+### Branch vs Pull Request Context
+
+- **Long-lived branches** (main, develop): use `branch`. Discover names with `list_branches`.
+- **Pull requests / feature branches**: use `pullRequest`. Discover keys with `list_pull_requests`.
+- Never pass a git branch name to a `pullRequest` parameter.
+
+```javascript
+// Compare quality gate on develop vs main
+list_branches({ projectKey: "my-project" });
+get_project_quality_gate_status({ projectKey: "my-project", branch: "develop" });
+
+// Analyze an open pull request
+list_pull_requests({ projectKey: "my-project" });
+search_sonar_issues_in_projects({ projects: ["my-project"], pullRequest: "123" });
 ```
 
 **Managing Issue Status:**
@@ -219,7 +230,7 @@ const analysis = analyze_code_snippet({
 // Step 1: Search for issues in the pull request
 const issues = search_sonar_issues_in_projects({
     projects: ["my-project"],
-    pullRequestId: "123",
+    pullRequest: "123",
     severities: ["HIGH", "BLOCKER"],
     impactSoftwareQualities: ["SECURITY", "RELIABILITY"]
 });
@@ -276,7 +287,7 @@ const issues = search_sonar_issues_in_projects({
 // Step 1: Search for dependency risks (requires Server 2025.4+ Enterprise with Advanced Security)
 const risks = search_dependency_risks({
     projectKey: "my-project",
-    branchKey: "main"
+    branch: "main"
 });
 
 // Step 2: Review high-severity vulnerabilities

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -87,9 +87,10 @@ import org.sonarsource.sonarqube.mcp.tools.system.SystemInfoTool;
 import org.sonarsource.sonarqube.mcp.tools.system.SystemLogsTool;
 import org.sonarsource.sonarqube.mcp.tools.system.SystemPingTool;
 import org.sonarsource.sonarqube.mcp.tools.system.SystemStatusTool;
+import org.sonarsource.sonarqube.mcp.tools.branches.ListBranchesTool;
+import org.sonarsource.sonarqube.mcp.tools.pullrequests.ListPullRequestsTool;
 import org.sonarsource.sonarqube.mcp.tools.webhooks.CreateWebhookTool;
 import org.sonarsource.sonarqube.mcp.tools.webhooks.ListWebhooksTool;
-import org.sonarsource.sonarqube.mcp.tools.pullrequests.ListPullRequestsTool;
 import org.sonarsource.sonarqube.mcp.transport.HttpServerTransportProvider;
 import org.sonarsource.sonarqube.mcp.transport.StdioServerTransportProvider;
 
@@ -106,6 +107,14 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     4. When a user mentions a project by name, use `search_my_sonarqube_projects` to find the exact key.
     5. If no key is found, use `search_my_sonarqube_projects` to list projects.
     An incorrect project key will silently return results from the wrong project.
+    """;
+  private static final String BRANCH_PULL_REQUEST_INSTRUCTIONS = """
+    ## Branch vs Pull Request Context
+    - Long-lived branches (main, develop, release/*): use `branch`. Discover names with `list_branches`.
+    - Pull requests / feature branches: use `pullRequest`. Discover keys with `list_pull_requests`.
+    - Never pass a git branch name to a pullRequest parameter — it expects the SonarQube PR key.
+    - Never provide both branch and pullRequest on the same call.
+    - Omit both to query the default (main) branch analysis.
     """;
   private static final String BASE_INSTRUCTIONS_WITH_ANALYSIS = "Transform your code quality workflow with SonarQube integration. " +
     "Analyze code, monitor project health, investigate issues, and understand quality gates. " +
@@ -377,7 +386,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       new GetDuplicationsTool(this),
       new SearchDuplicatedFilesTool(this, configuredProjectKey),
       new ListPortfoliosTool(this, mcpConfiguration.isSonarQubeCloud()),
-      new ListPullRequestsTool(this, configuredProjectKey)));
+      new ListPullRequestsTool(this, configuredProjectKey),
+      new ListBranchesTool(this, configuredProjectKey)));
 
     if (mcpConfiguration.isHttpEnabled()) {
       // In HTTP mode there is no startup token to probe SCA availability
@@ -462,6 +472,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     composedInstructions = mcpConfiguration.isToolCategoryEnabled(ToolCategory.ANALYSIS)
       ? BASE_INSTRUCTIONS_WITH_ANALYSIS
       : BASE_INSTRUCTIONS_WITHOUT_ANALYSIS;
+    composedInstructions += "\n" + BRANCH_PULL_REQUEST_INSTRUCTIONS;
     if (mcpConfiguration.getProjectKey() == null) {
       composedInstructions += "\n" + PROJECT_KEY_INSTRUCTIONS;
     }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/ServerApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/ServerApi.java
@@ -17,6 +17,7 @@
 package org.sonarsource.sonarqube.mcp.serverapi;
 
 import org.sonarsource.sonarqube.mcp.serverapi.a3s.A3sAnalysisApi;
+import org.sonarsource.sonarqube.mcp.serverapi.branches.ProjectBranchesApi;
 import org.sonarsource.sonarqube.mcp.serverapi.components.ComponentsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.duplications.DuplicationsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.enterprises.EnterprisesApi;
@@ -127,6 +128,10 @@ public class ServerApi {
 
   public PullRequestsApi pullRequestsApi() {
     return new PullRequestsApi(helper);
+  }
+
+  public ProjectBranchesApi projectBranchesApi() {
+    return new ProjectBranchesApi(helper);
   }
 
   public UsersApi usersApi() {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/ProjectBranchesApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/ProjectBranchesApi.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.serverapi.branches;
+
+import com.google.gson.Gson;
+import org.sonarsource.sonarqube.mcp.serverapi.ServerApiHelper;
+import org.sonarsource.sonarqube.mcp.serverapi.UrlBuilder;
+import org.sonarsource.sonarqube.mcp.serverapi.branches.response.BranchesListResponse;
+
+public class ProjectBranchesApi {
+
+  public static final String BRANCHES_LIST_PATH = "/api/project_branches/list";
+
+  private final ServerApiHelper helper;
+
+  public ProjectBranchesApi(ServerApiHelper helper) {
+    this.helper = helper;
+  }
+
+  public BranchesListResponse listBranches(String projectKey) {
+    var url = new UrlBuilder(BRANCHES_LIST_PATH)
+      .addParam("project", projectKey)
+      .build();
+
+    try (var response = helper.get(url)) {
+      var responseStr = response.bodyAsString();
+      return new Gson().fromJson(responseStr, BranchesListResponse.class);
+    }
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/package-info.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@ParametersAreNonnullByDefault
+package org.sonarsource.sonarqube.mcp.serverapi.branches;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/BranchesListResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/BranchesListResponse.java
@@ -23,11 +23,11 @@ public record BranchesListResponse(List<Branch> branches) {
 
   public record Branch(
     String name,
-    @Nullable Boolean isMain,
-    @Nullable String type,
+    boolean isMain,
+    String type,
     @Nullable Status status,
     @Nullable String analysisDate,
-    @Nullable String branchId
+    String branchId
   ) {
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/BranchesListResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/BranchesListResponse.java
@@ -1,0 +1,37 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.serverapi.branches.response;
+
+import java.util.List;
+import jakarta.annotation.Nullable;
+
+public record BranchesListResponse(List<Branch> branches) {
+
+  public record Branch(
+    String name,
+    @Nullable Boolean isMain,
+    @Nullable String type,
+    @Nullable Status status,
+    @Nullable String analysisDate,
+    @Nullable String branchId
+  ) {
+  }
+
+  public record Status(@Nullable String qualityGateStatus) {
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/package-info.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@ParametersAreNonnullByDefault
+package org.sonarsource.sonarqube.mcp.serverapi.branches.response;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/issues/IssuesApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/issues/IssuesApi.java
@@ -41,7 +41,7 @@ public class IssuesApi {
     @Nullable List<String> projects,
     @Nullable String branch,
     @Nullable List<String> files,
-    @Nullable String pullRequestId,
+    @Nullable String pullRequest,
     @Nullable List<String> severities,
     @Nullable List<String> impactSoftwareQualities,
     @Nullable List<String> issueStatuses,
@@ -84,7 +84,7 @@ public class IssuesApi {
     var builder = new UrlBuilder(SEARCH_PATH)
       .addParam(componentsParamName, mergedComponents(params.projects(), params.files()))
       .addParam("branch", params.branch())
-      .addParam("pullRequest", params.pullRequestId())
+      .addParam("pullRequest", params.pullRequest())
       .addParam("impactSeverities", params.severities())
       .addParam("impactSoftwareQualities", params.impactSoftwareQualities())
       .addParam("issueStatuses", params.issueStatuses())

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContext.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContext.java
@@ -36,6 +36,18 @@ public final class BranchPullRequestContext {
     // utility class
   }
 
+  public record Params(@Nullable String branch, @Nullable String pullRequest) {
+    public Optional<Tool.Result> validationError() {
+      return validateMutualExclusion(branch, pullRequest);
+    }
+  }
+
+  public static Params from(Tool.Arguments arguments) {
+    return new Params(
+      arguments.getOptionalString(BRANCH_PROPERTY),
+      arguments.getOptionalString(PULL_REQUEST_PROPERTY));
+  }
+
   public static Optional<Tool.Result> validateMutualExclusion(@Nullable String branch, @Nullable String pullRequest) {
     if (branch != null && pullRequest != null) {
       return Optional.of(Tool.Result.failure(

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContext.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContext.java
@@ -1,0 +1,48 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools;
+
+import java.util.Optional;
+import jakarta.annotation.Nullable;
+
+public final class BranchPullRequestContext {
+
+  public static final String BRANCH_PROPERTY = "branch";
+  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+
+  public static final String BRANCH_PROPERTY_DESCRIPTION = """
+    Long-lived branch name in SonarQube (e.g. 'main', 'develop'). Use list_branches to discover valid names. \
+    Not for feature branches or pull request analysis — use pullRequest instead.""";
+
+  public static final String PULL_REQUEST_PROPERTY_DESCRIPTION = """
+    Pull request key/ID in SonarQube. Use list_pull_requests to discover valid keys. \
+    Not for long-lived branches — use branch instead. Must be the SonarQube PR key, not a git branch name.""";
+
+  private BranchPullRequestContext() {
+    // utility class
+  }
+
+  public static Optional<Tool.Result> validateMutualExclusion(@Nullable String branch, @Nullable String pullRequest) {
+    if (branch != null && pullRequest != null) {
+      return Optional.of(Tool.Result.failure(
+        "Cannot use 'branch' and 'pullRequest' together. Use 'branch' for long-lived branches (see list_branches) "
+          + "or 'pullRequest' for pull requests (see list_pull_requests)."));
+    }
+    return Optional.empty();
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/SchemaToolBuilder.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/SchemaToolBuilder.java
@@ -79,6 +79,14 @@ public class SchemaToolBuilder {
     return this;
   }
 
+  public SchemaToolBuilder addBranchProperty() {
+    return addStringProperty(BranchPullRequestContext.BRANCH_PROPERTY, BranchPullRequestContext.BRANCH_PROPERTY_DESCRIPTION);
+  }
+
+  public SchemaToolBuilder addPullRequestProperty() {
+    return addStringProperty(BranchPullRequestContext.PULL_REQUEST_PROPERTY, BranchPullRequestContext.PULL_REQUEST_PROPERTY_DESCRIPTION);
+  }
+
   public SchemaToolBuilder addRequiredStringProperty(String propertyName, String description) {
     addStringProperty(propertyName, description);
     requiredProperties.add(propertyName);

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/SchemaToolBuilder.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/SchemaToolBuilder.java
@@ -79,12 +79,9 @@ public class SchemaToolBuilder {
     return this;
   }
 
-  public SchemaToolBuilder addBranchProperty() {
-    return addStringProperty(BranchPullRequestContext.BRANCH_PROPERTY, BranchPullRequestContext.BRANCH_PROPERTY_DESCRIPTION);
-  }
-
-  public SchemaToolBuilder addPullRequestProperty() {
-    return addStringProperty(BranchPullRequestContext.PULL_REQUEST_PROPERTY, BranchPullRequestContext.PULL_REQUEST_PROPERTY_DESCRIPTION);
+  public SchemaToolBuilder addBranchAndPullRequestProperties() {
+    return addStringProperty(BranchPullRequestContext.BRANCH_PROPERTY, BranchPullRequestContext.BRANCH_PROPERTY_DESCRIPTION)
+      .addStringProperty(BranchPullRequestContext.PULL_REQUEST_PROPERTY, BranchPullRequestContext.PULL_REQUEST_PROPERTY_DESCRIPTION);
   }
 
   public SchemaToolBuilder addRequiredStringProperty(String propertyName, String description) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/BranchTypes.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/BranchTypes.java
@@ -1,0 +1,63 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools.branches;
+
+import jakarta.annotation.Nullable;
+
+public final class BranchTypes {
+
+  public enum BranchType {
+    LONG, SHORT, BRANCH
+  }
+
+  public enum QualityGateStatus {
+    OK, ERROR, WARN, NONE
+  }
+
+  private BranchTypes() {
+    // utility class
+  }
+
+  public static boolean isLongLivedBranchType(@Nullable String type) {
+    return "LONG".equals(type) || "BRANCH".equals(type);
+  }
+
+  @Nullable
+  public static BranchType parseBranchType(@Nullable String type) {
+    if (type == null) {
+      return null;
+    }
+    try {
+      return BranchType.valueOf(type);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  public static QualityGateStatus parseQualityGateStatus(@Nullable String status) {
+    if (status == null || status.isBlank()) {
+      return null;
+    }
+    try {
+      return QualityGateStatus.valueOf(status);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
@@ -22,6 +22,10 @@ import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
 
+import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.isLongLivedBranchType;
+import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseBranchType;
+import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseQualityGateStatus;
+
 public class ListBranchesTool extends Tool {
 
   public static final String TOOL_NAME = "list_branches";
@@ -35,9 +39,9 @@ public class ListBranchesTool extends Tool {
     super(SchemaToolBuilder.forOutput(ListBranchesToolResponse.class)
         .setName(TOOL_NAME)
         .setTitle("List SonarQube Branches")
-        .setDescription("List branches for a project. " +
+        .setDescription("List long-lived branches for a project (e.g. main, develop, master). " +
           "Use returned branch names as the branch parameter on other tools (e.g. get_project_quality_gate_status, get_component_measures). " +
-          "For pull requests and feature branches, use list_pull_requests instead.")
+          "For pull requests, use list_pull_requests instead.")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "Project key (e.g. my_project)", configuredProjectKey)
         .setReadOnlyHint()
         .build(),
@@ -53,11 +57,12 @@ public class ListBranchesTool extends Tool {
     var response = serverApiProvider.get().projectBranchesApi().listBranches(projectKey);
 
     var branches = response.branches().stream()
+      .filter(branch -> isLongLivedBranchType(branch.type()))
       .map(branch -> new ListBranchesToolResponse.Branch(
         branch.name(),
-        Boolean.TRUE.equals(branch.isMain()),
-        branch.type(),
-        branch.status() != null ? branch.status().qualityGateStatus() : null,
+        branch.isMain(),
+        parseBranchType(branch.type()),
+        branch.status() != null ? parseQualityGateStatus(branch.status().qualityGateStatus()) : null,
         branch.analysisDate(),
         branch.branchId()
       ))

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-package org.sonarsource.sonarqube.mcp.tools.pullrequests;
+package org.sonarsource.sonarqube.mcp.tools.branches;
 
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
@@ -22,23 +22,22 @@ import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
 
-public class ListPullRequestsTool extends Tool {
+public class ListBranchesTool extends Tool {
 
-  public static final String TOOL_NAME = "list_pull_requests";
+  public static final String TOOL_NAME = "list_branches";
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
 
   private final ServerApiProvider serverApiProvider;
   @Nullable
   private final String configuredProjectKey;
 
-  public ListPullRequestsTool(ServerApiProvider serverApiProvider, @Nullable String configuredProjectKey) {
-    super(SchemaToolBuilder.forOutput(ListPullRequestsToolResponse.class)
+  public ListBranchesTool(ServerApiProvider serverApiProvider, @Nullable String configuredProjectKey) {
+    super(SchemaToolBuilder.forOutput(ListBranchesToolResponse.class)
         .setName(TOOL_NAME)
-        .setTitle("List SonarQube Pull Requests")
-        .setDescription("List all pull requests for a project. " +
-          "Use this tool to discover available pull requests and their corresponding branch names before analyzing their coverage, issues, or quality. " +
-          "Returns the pull request key/ID and source branch for each PR, which can be used with other tools that accept a pullRequest parameter. " +
-          "For long-lived branches (main, develop), use list_branches instead.")
+        .setTitle("List SonarQube Branches")
+        .setDescription("List branches for a project. " +
+          "Use returned branch names as the branch parameter on other tools (e.g. get_project_quality_gate_status, get_component_measures). " +
+          "For pull requests and feature branches, use list_pull_requests instead.")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "Project key (e.g. my_project)", configuredProjectKey)
         .setReadOnlyHint()
         .build(),
@@ -51,20 +50,23 @@ public class ListPullRequestsTool extends Tool {
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
 
-    var response = serverApiProvider.get().pullRequestsApi().listPullRequests(projectKey);
+    var response = serverApiProvider.get().projectBranchesApi().listBranches(projectKey);
 
-    var pullRequests = response.pullRequests().stream()
-      .map(pr -> new ListPullRequestsToolResponse.PullRequest(
-        pr.key(),
-        pr.title(),
-        pr.branch()
+    var branches = response.branches().stream()
+      .map(branch -> new ListBranchesToolResponse.Branch(
+        branch.name(),
+        Boolean.TRUE.equals(branch.isMain()),
+        branch.type(),
+        branch.status() != null ? branch.status().qualityGateStatus() : null,
+        branch.analysisDate(),
+        branch.branchId()
       ))
       .toList();
 
-    var toolResponse = new ListPullRequestsToolResponse(
+    var toolResponse = new ListBranchesToolResponse(
       projectKey,
-      pullRequests.size(),
-      pullRequests
+      branches.size(),
+      branches
     );
 
     return Tool.Result.success(toolResponse);

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
@@ -1,0 +1,39 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools.branches;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+import jakarta.annotation.Nullable;
+
+public record ListBranchesToolResponse(
+  @JsonPropertyDescription("Project key") String projectKey,
+  @JsonPropertyDescription("Total number of branches") int totalBranches,
+  @JsonPropertyDescription("List of branches for this project") List<Branch> branches
+) {
+
+  public record Branch(
+    @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
+    @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
+    @JsonPropertyDescription("Branch type in SonarQube") @Nullable String type,
+    @JsonPropertyDescription("Quality gate status for this branch") @Nullable String qualityGateStatus,
+    @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
+    @JsonPropertyDescription("Internal branch identifier") @Nullable String branchId
+  ) {
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
@@ -19,6 +19,8 @@ package org.sonarsource.sonarqube.mcp.tools.branches;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import jakarta.annotation.Nullable;
+import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.BranchType;
+import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.QualityGateStatus;
 
 public record ListBranchesToolResponse(
   @JsonPropertyDescription("Project key") String projectKey,
@@ -29,10 +31,10 @@ public record ListBranchesToolResponse(
   public record Branch(
     @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
     @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
-    @JsonPropertyDescription("Branch type in SonarQube") @Nullable String type,
-    @JsonPropertyDescription("Quality gate status for this branch") @Nullable String qualityGateStatus,
+    @JsonPropertyDescription("Branch type in SonarQube (LONG on SonarCloud, BRANCH on SonarQube Server)") @Nullable BranchType type,
+    @JsonPropertyDescription("Quality gate status for this branch") @Nullable QualityGateStatus qualityGateStatus,
     @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
-    @JsonPropertyDescription("Internal branch identifier") @Nullable String branchId
+    @JsonPropertyDescription("Internal branch identifier") String branchId
   ) {
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
@@ -31,7 +31,7 @@ public record ListBranchesToolResponse(
   public record Branch(
     @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
     @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
-    @JsonPropertyDescription("Branch type in SonarQube (LONG on SonarCloud, BRANCH on SonarQube Server)") @Nullable BranchType type,
+    @JsonPropertyDescription("Branch type in SonarQube (LONG on SonarQube Cloud, BRANCH on SonarQube Server)") @Nullable BranchType type,
     @JsonPropertyDescription("Quality gate status for this branch") @Nullable QualityGateStatus qualityGateStatus,
     @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
     @JsonPropertyDescription("Internal branch identifier") String branchId

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/package-info.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@ParametersAreNonnullByDefault
+package org.sonarsource.sonarqube.mcp.tools.branches;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksTool.java
@@ -48,8 +48,7 @@ public class SearchDependencyRisksTool extends Tool {
       .setDescription("Search for software composition analysis issues (dependency risks) of a project, " +
         "paired with releases that appear in the analyzed project, application, or portfolio.")
       .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "The project key", configuredProjectKey)
-      .addBranchProperty()
-      .addPullRequestProperty()
+      .addBranchAndPullRequestProperties()
       .addNumberProperty(PAGE_INDEX_PROPERTY, "An optional page index (1-based). Defaults to 1.")
       .addNumberProperty(PAGE_SIZE_PROPERTY, "An optional page size. Must be greater than 0 and less than or equal to 500. Defaults to 100.")
       .setReadOnlyHint()
@@ -73,17 +72,17 @@ public class SearchDependencyRisksTool extends Tool {
       return Tool.Result.failure("Search Dependency Risks tool is not available for SonarQube Server because Advanced Security is not enabled.");
     }
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
     var pageIndex = arguments.getOptionalInteger(PAGE_INDEX_PROPERTY);
     var pageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
 
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
-    var response = provider.scaApi().getDependencyRisks(projectKey, branch, pullRequest, pageIndex, pageSize);
+    var response = provider.scaApi().getDependencyRisks(
+      projectKey, branchPullRequest.branch(), branchPullRequest.pullRequest(), pageIndex, pageSize);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksTool.java
@@ -21,6 +21,7 @@ import org.sonarsource.sonarqube.mcp.SonarQubeVersionChecker;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.features.Feature;
 import org.sonarsource.sonarqube.mcp.serverapi.sca.response.DependencyRisksResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -29,8 +30,8 @@ public class SearchDependencyRisksTool extends Tool {
 
   public static final String TOOL_NAME = "search_dependency_risks";
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String BRANCH_KEY_PROPERTY = "branchKey";
-  public static final String PULL_REQUEST_KEY_PROPERTY = "pullRequestKey";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
   public static final String PAGE_INDEX_PROPERTY = "pageIndex";
   public static final String PAGE_SIZE_PROPERTY = "pageSize";
 
@@ -47,8 +48,8 @@ public class SearchDependencyRisksTool extends Tool {
       .setDescription("Search for software composition analysis issues (dependency risks) of a project, " +
         "paired with releases that appear in the analyzed project, application, or portfolio.")
       .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "The project key", configuredProjectKey)
-      .addStringProperty(BRANCH_KEY_PROPERTY, "The branch key")
-      .addStringProperty(PULL_REQUEST_KEY_PROPERTY, "The pull request key")
+      .addBranchProperty()
+      .addPullRequestProperty()
       .addNumberProperty(PAGE_INDEX_PROPERTY, "An optional page index (1-based). Defaults to 1.")
       .addNumberProperty(PAGE_SIZE_PROPERTY, "An optional page size. Must be greater than 0 and less than or equal to 500. Defaults to 100.")
       .setReadOnlyHint()
@@ -72,12 +73,17 @@ public class SearchDependencyRisksTool extends Tool {
       return Tool.Result.failure("Search Dependency Risks tool is not available for SonarQube Server because Advanced Security is not enabled.");
     }
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
-    var branchKey = arguments.getOptionalString(BRANCH_KEY_PROPERTY);
-    var pullRequestKey = arguments.getOptionalString(PULL_REQUEST_KEY_PROPERTY);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
+    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
     var pageIndex = arguments.getOptionalInteger(PAGE_INDEX_PROPERTY);
     var pageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
 
-    var response = provider.scaApi().getDependencyRisks(projectKey, branchKey, pullRequestKey, pageIndex, pageSize);
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
+
+    var response = provider.scaApi().getDependencyRisks(projectKey, branch, pullRequest, pageIndex, pageSize);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/GetDuplicationsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/GetDuplicationsTool.java
@@ -38,8 +38,7 @@ public class GetDuplicationsTool extends Tool {
       .setTitle("Get SonarQube Code Duplications")
       .setDescription("Get duplications for a file. Requires Browse permission on file's project")
       .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.php)")
-      .addBranchProperty()
-      .addPullRequestProperty()
+      .addBranchAndPullRequestProperties()
       .setReadOnlyHint()
       .build(),
       ToolCategory.DUPLICATIONS);
@@ -49,15 +48,14 @@ public class GetDuplicationsTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
-
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
-    
-    var duplicationsResponse = serverApiProvider.get().duplicationsApi().getDuplications(key, branch, pullRequest);
+
+    var duplicationsResponse = serverApiProvider.get().duplicationsApi().getDuplications(
+      key, branchPullRequest.branch(), branchPullRequest.pullRequest());
     var response = buildStructuredContent(duplicationsResponse);
     return Tool.Result.success(response);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/GetDuplicationsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/GetDuplicationsTool.java
@@ -18,6 +18,7 @@ package org.sonarsource.sonarqube.mcp.tools.duplications;
 
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.duplications.response.DuplicationsResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -26,7 +27,8 @@ public class GetDuplicationsTool extends Tool {
 
   public static final String TOOL_NAME = "get_duplications";
   public static final String KEY_PROPERTY = "key";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;
 
@@ -36,7 +38,8 @@ public class GetDuplicationsTool extends Tool {
       .setTitle("Get SonarQube Code Duplications")
       .setDescription("Get duplications for a file. Requires Browse permission on file's project")
       .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.php)")
-      .addStringProperty(PULL_REQUEST_PROPERTY, "Pull request id")
+      .addBranchProperty()
+      .addPullRequestProperty()
       .setReadOnlyHint()
       .build(),
       ToolCategory.DUPLICATIONS);
@@ -46,9 +49,15 @@ public class GetDuplicationsTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
     
-    var duplicationsResponse = serverApiProvider.get().duplicationsApi().getDuplications(key, null, pullRequest);
+    var duplicationsResponse = serverApiProvider.get().duplicationsApi().getDuplications(key, branch, pullRequest);
     var response = buildStructuredContent(duplicationsResponse);
     return Tool.Result.success(response);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/SearchDuplicatedFilesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/SearchDuplicatedFilesTool.java
@@ -61,8 +61,7 @@ public class SearchDuplicatedFilesTool extends Tool {
         .setDescription("Search for files with code duplications in a project. " +
           "By default, automatically fetches all duplicated files across all pages (up to 10,000 files max).")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "Project key (e.g. my_project)", configuredProjectKey)
-        .addBranchProperty()
-        .addPullRequestProperty()
+        .addBranchAndPullRequestProperties()
         .addNumberProperty(PAGE_SIZE_PROPERTY, "Optional: Number of results per page for manual pagination (max: 500). " +
           "If not specified, auto-fetches all duplicated files.")
         .addNumberProperty(PAGE_INDEX_PROPERTY, "Optional: Page number for manual pagination (starts at 1). " +
@@ -77,29 +76,28 @@ public class SearchDuplicatedFilesTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
     var requestedPageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
     var requestedPageIndex = arguments.getOptionalInteger(PAGE_INDEX_PROPERTY);
 
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
     // If user explicitly provided pagination parameters, use single-page mode
     var manualPagination = requestedPageSize != null || requestedPageIndex != null;
 
     if (manualPagination) {
-      return executeSinglePage(projectKey, branch, pullRequest, requestedPageSize != null ? requestedPageSize : DEFAULT_PAGE_SIZE,
+      return executeSinglePage(projectKey, branchPullRequest, requestedPageSize != null ? requestedPageSize : DEFAULT_PAGE_SIZE,
         requestedPageIndex != null ? requestedPageIndex : DEFAULT_PAGE_INDEX);
     }
 
     // Auto-fetch mode: fetch all pages to get all duplicated files
-    return executeAutoFetch(projectKey, branch, pullRequest);
+    return executeAutoFetch(projectKey, branchPullRequest);
   }
 
-  private Tool.Result executeSinglePage(String projectKey, @Nullable String branch, @Nullable String pullRequest, int pageSize, int pageIndex) {
+  private Tool.Result executeSinglePage(String projectKey, BranchPullRequestContext.Params branchPullRequest, int pageSize, int pageIndex) {
     if (pageSize <= 0 || pageSize > MAX_PAGE_SIZE) {
       return Tool.Result.failure("Page size must be between 1 and " + MAX_PAGE_SIZE);
     }
@@ -107,9 +105,11 @@ public class SearchDuplicatedFilesTool extends Tool {
       return Tool.Result.failure("Page index must be greater than 0");
     }
 
-    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest);
-    
-    var params = new ComponentTreeParams(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest, FILE_QUALIFIER, STRATEGY, null,
+    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(
+      projectKey, branchPullRequest.branch(), DUPLICATION_METRIC_KEYS, branchPullRequest.pullRequest());
+
+    var params = new ComponentTreeParams(projectKey, branchPullRequest.branch(), DUPLICATION_METRIC_KEYS, branchPullRequest.pullRequest(),
+      FILE_QUALIFIER, STRATEGY, null,
       null, null, pageIndex, pageSize, "metrics");
     var componentTree = serverApiProvider.get().measuresApi().getComponentTree(params);
 
@@ -117,15 +117,17 @@ public class SearchDuplicatedFilesTool extends Tool {
     return Tool.Result.success(response);
   }
 
-  private Tool.Result executeAutoFetch(String projectKey, @Nullable String branch, @Nullable String pullRequest) {
-    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest);
+  private Tool.Result executeAutoFetch(String projectKey, BranchPullRequestContext.Params branchPullRequest) {
+    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(
+      projectKey, branchPullRequest.branch(), DUPLICATION_METRIC_KEYS, branchPullRequest.pullRequest());
 
     var allDuplicatedFiles = new ArrayList<ComponentTreeResponse.Component>();
     var currentPage = 1;
     var shouldContinue = true;
 
     while (currentPage <= MAX_PAGES_TO_FETCH && shouldContinue) {
-      var params = new ComponentTreeParams(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest, FILE_QUALIFIER, STRATEGY,
+      var params = new ComponentTreeParams(projectKey, branchPullRequest.branch(), DUPLICATION_METRIC_KEYS, branchPullRequest.pullRequest(),
+        FILE_QUALIFIER, STRATEGY,
         null, null, null, currentPage, MAX_PAGE_SIZE, "metrics");
       var componentTree = serverApiProvider.get().measuresApi().getComponentTree(params);
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/SearchDuplicatedFilesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/SearchDuplicatedFilesTool.java
@@ -23,16 +23,17 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.ComponentTreeParams;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.response.ComponentMeasuresResponse;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.response.ComponentTreeResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
-
 
 public class SearchDuplicatedFilesTool extends Tool {
 
   public static final String TOOL_NAME = "search_duplicated_files";
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
   public static final String PAGE_SIZE_PROPERTY = "pageSize";
   public static final String PAGE_INDEX_PROPERTY = "pageIndex";
 
@@ -60,7 +61,8 @@ public class SearchDuplicatedFilesTool extends Tool {
         .setDescription("Search for files with code duplications in a project. " +
           "By default, automatically fetches all duplicated files across all pages (up to 10,000 files max).")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "Project key (e.g. my_project)", configuredProjectKey)
-        .addStringProperty(PULL_REQUEST_PROPERTY, "Pull request id")
+        .addBranchProperty()
+        .addPullRequestProperty()
         .addNumberProperty(PAGE_SIZE_PROPERTY, "Optional: Number of results per page for manual pagination (max: 500). " +
           "If not specified, auto-fetches all duplicated files.")
         .addNumberProperty(PAGE_INDEX_PROPERTY, "Optional: Page number for manual pagination (starts at 1). " +
@@ -75,23 +77,29 @@ public class SearchDuplicatedFilesTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
     var requestedPageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
     var requestedPageIndex = arguments.getOptionalInteger(PAGE_INDEX_PROPERTY);
+
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
 
     // If user explicitly provided pagination parameters, use single-page mode
     var manualPagination = requestedPageSize != null || requestedPageIndex != null;
 
     if (manualPagination) {
-      return executeSinglePage(projectKey, pullRequest, requestedPageSize != null ? requestedPageSize : DEFAULT_PAGE_SIZE,
+      return executeSinglePage(projectKey, branch, pullRequest, requestedPageSize != null ? requestedPageSize : DEFAULT_PAGE_SIZE,
         requestedPageIndex != null ? requestedPageIndex : DEFAULT_PAGE_INDEX);
     }
 
     // Auto-fetch mode: fetch all pages to get all duplicated files
-    return executeAutoFetch(projectKey, pullRequest);
+    return executeAutoFetch(projectKey, branch, pullRequest);
   }
 
-  private Tool.Result executeSinglePage(String projectKey, @Nullable String pullRequest, int pageSize, int pageIndex) {
+  private Tool.Result executeSinglePage(String projectKey, @Nullable String branch, @Nullable String pullRequest, int pageSize, int pageIndex) {
     if (pageSize <= 0 || pageSize > MAX_PAGE_SIZE) {
       return Tool.Result.failure("Page size must be between 1 and " + MAX_PAGE_SIZE);
     }
@@ -99,9 +107,9 @@ public class SearchDuplicatedFilesTool extends Tool {
       return Tool.Result.failure("Page index must be greater than 0");
     }
 
-    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, null, DUPLICATION_METRIC_KEYS, pullRequest);
+    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest);
     
-    var params = new ComponentTreeParams(projectKey, null, DUPLICATION_METRIC_KEYS, pullRequest, FILE_QUALIFIER, STRATEGY, null,
+    var params = new ComponentTreeParams(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest, FILE_QUALIFIER, STRATEGY, null,
       null, null, pageIndex, pageSize, "metrics");
     var componentTree = serverApiProvider.get().measuresApi().getComponentTree(params);
 
@@ -109,15 +117,15 @@ public class SearchDuplicatedFilesTool extends Tool {
     return Tool.Result.success(response);
   }
 
-  private Tool.Result executeAutoFetch(String projectKey, @Nullable String pullRequest) {
-    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, null, DUPLICATION_METRIC_KEYS, pullRequest);
+  private Tool.Result executeAutoFetch(String projectKey, @Nullable String branch, @Nullable String pullRequest) {
+    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest);
 
     var allDuplicatedFiles = new ArrayList<ComponentTreeResponse.Component>();
     var currentPage = 1;
     var shouldContinue = true;
 
     while (currentPage <= MAX_PAGES_TO_FETCH && shouldContinue) {
-      var params = new ComponentTreeParams(projectKey, null, DUPLICATION_METRIC_KEYS, pullRequest, FILE_QUALIFIER, STRATEGY,
+      var params = new ComponentTreeParams(projectKey, branch, DUPLICATION_METRIC_KEYS, pullRequest, FILE_QUALIFIER, STRATEGY,
         null, null, null, currentPage, MAX_PAGE_SIZE, "metrics");
       var componentTree = serverApiProvider.get().measuresApi().getComponentTree(params);
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsTool.java
@@ -53,8 +53,7 @@ public class SearchSecurityHotspotsTool extends Tool {
       .setDescription("Search for Security Hotspots in a project.")
       .addStringProperty(PROJECT_KEY_PROPERTY, "The key of the project or application to search in. Required unless hotspotKeys is provided.")
       .addArrayProperty(HOTSPOT_KEYS_PROPERTY, "string", "Comma-separated list of specific Security Hotspot keys to retrieve. Required unless projectKey is provided.")
-      .addBranchProperty()
-      .addPullRequestProperty()
+      .addBranchAndPullRequestProperties()
       .addArrayProperty(FILES_PROPERTY, "string", "An optional list of file paths to filter Security Hotspots")
       .addEnumProperty(STATUS_PROPERTY, VALID_STATUSES, "Filter by review status")
       .addEnumProperty(RESOLUTION_PROPERTY, VALID_RESOLUTIONS, "Filter by resolution (when status is REVIEWED)")
@@ -75,14 +74,13 @@ public class SearchSecurityHotspotsTool extends Tool {
       return Tool.Result.failure(validationError);
     }
 
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
+    var branchPullRequestError = branchPullRequest.validationError();
+    if (branchPullRequestError.isPresent()) {
+      return branchPullRequestError.get();
     }
-    
-    var searchParams = extractSearchParams(arguments, branch);
+
+    var searchParams = extractSearchParams(arguments, branchPullRequest);
     var response = serverApiProvider.get().hotspotsApi().search(searchParams);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
@@ -103,11 +101,11 @@ public class SearchSecurityHotspotsTool extends Tool {
     return null;
   }
 
-  private static HotspotsApi.SearchParams extractSearchParams(Tool.Arguments arguments, @Nullable String branch) {
+  private static HotspotsApi.SearchParams extractSearchParams(Tool.Arguments arguments, BranchPullRequestContext.Params branchPullRequest) {
     return new HotspotsApi.SearchParams(
       arguments.getOptionalString(PROJECT_KEY_PROPERTY),
-      branch,
-      arguments.getOptionalString(PULL_REQUEST_PROPERTY),
+      branchPullRequest.branch(),
+      branchPullRequest.pullRequest(),
       arguments.getOptionalStringList(FILES_PROPERTY),
       arguments.getOptionalStringList(HOTSPOT_KEYS_PROPERTY),
       arguments.getOptionalEnumValue(STATUS_PROPERTY, VALID_STATUSES),

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsTool.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.hotspots.HotspotsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.hotspots.response.SearchResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -30,7 +31,8 @@ public class SearchSecurityHotspotsTool extends Tool {
 
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
   public static final String HOTSPOT_KEYS_PROPERTY = "hotspotKeys";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
   public static final String FILES_PROPERTY = "files";
   public static final String STATUS_PROPERTY = "status";
   public static final String RESOLUTION_PROPERTY = "resolution";
@@ -51,7 +53,8 @@ public class SearchSecurityHotspotsTool extends Tool {
       .setDescription("Search for Security Hotspots in a project.")
       .addStringProperty(PROJECT_KEY_PROPERTY, "The key of the project or application to search in. Required unless hotspotKeys is provided.")
       .addArrayProperty(HOTSPOT_KEYS_PROPERTY, "string", "Comma-separated list of specific Security Hotspot keys to retrieve. Required unless projectKey is provided.")
-      .addStringProperty(PULL_REQUEST_PROPERTY, "The identifier of the Pull Request to search in")
+      .addBranchProperty()
+      .addPullRequestProperty()
       .addArrayProperty(FILES_PROPERTY, "string", "An optional list of file paths to filter Security Hotspots")
       .addEnumProperty(STATUS_PROPERTY, VALID_STATUSES, "Filter by review status")
       .addEnumProperty(RESOLUTION_PROPERTY, VALID_RESOLUTIONS, "Filter by resolution (when status is REVIEWED)")
@@ -71,8 +74,15 @@ public class SearchSecurityHotspotsTool extends Tool {
     if (validationError != null) {
       return Tool.Result.failure(validationError);
     }
+
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
+    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
     
-    var searchParams = extractSearchParams(arguments);
+    var searchParams = extractSearchParams(arguments, branch);
     var response = serverApiProvider.get().hotspotsApi().search(searchParams);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
@@ -93,10 +103,10 @@ public class SearchSecurityHotspotsTool extends Tool {
     return null;
   }
 
-  private static HotspotsApi.SearchParams extractSearchParams(Tool.Arguments arguments) {
+  private static HotspotsApi.SearchParams extractSearchParams(Tool.Arguments arguments, @Nullable String branch) {
     return new HotspotsApi.SearchParams(
       arguments.getOptionalString(PROJECT_KEY_PROPERTY),
-      null,
+      branch,
       arguments.getOptionalString(PULL_REQUEST_PROPERTY),
       arguments.getOptionalStringList(FILES_PROPERTY),
       arguments.getOptionalStringList(HOTSPOT_KEYS_PROPERTY),

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
@@ -17,7 +17,6 @@
 package org.sonarsource.sonarqube.mcp.tools.issues;
 
 import io.modelcontextprotocol.spec.McpSchema;
-import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.issues.IssuesApi;
 import org.sonarsource.sonarqube.mcp.serverapi.issues.response.SearchResponse;
@@ -64,8 +63,7 @@ public class SearchIssuesTool extends Tool {
       .setDescription(description)
       .addArrayProperty(PROJECTS_PROPERTY, "string", "An optional list of Sonar projects to look in")
       .addArrayProperty(FILES_PROPERTY, "string", "An optional list of component keys (files, directories, modules) to filter issues")
-      .addBranchProperty()
-      .addPullRequestProperty()
+      .addBranchAndPullRequestProperties()
       .addEnumProperty(SEVERITIES_PROPERTY, VALID_SEVERITIES, "An optional list of severities to filter by")
       .addEnumProperty(IMPACT_SOFTWARE_QUALITIES_PROPERTY, VALID_IMPACT_SOFTWARE_QUALITIES, "An optional list of software qualities to filter by")
       .addEnumProperty(ISSUE_STATUSES_PROPERTY, VALID_ISSUE_STATUSES, "An optional list of issue statuses to filter by. Note: IN_SANDBOX is valid only for SonarQube Server")
@@ -78,26 +76,24 @@ public class SearchIssuesTool extends Tool {
 
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
-
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
-    var searchParams = extractSearchParams(arguments, branch);
+    var searchParams = extractSearchParams(arguments, branchPullRequest);
     var response = serverApiProvider.get().issuesApi().search(searchParams);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
   }
 
-  private static IssuesApi.SearchParams extractSearchParams(Tool.Arguments arguments, @Nullable String branch) {
+  private static IssuesApi.SearchParams extractSearchParams(Tool.Arguments arguments, BranchPullRequestContext.Params branchPullRequest) {
     return new IssuesApi.SearchParams(
       arguments.getOptionalStringList(PROJECTS_PROPERTY),
-      branch,
+      branchPullRequest.branch(),
       arguments.getOptionalStringList(FILES_PROPERTY),
-      arguments.getOptionalString(PULL_REQUEST_PROPERTY),
+      branchPullRequest.pullRequest(),
       arguments.getOptionalEnumList(SEVERITIES_PROPERTY, VALID_SEVERITIES),
       arguments.getOptionalEnumList(IMPACT_SOFTWARE_QUALITIES_PROPERTY, VALID_IMPACT_SOFTWARE_QUALITIES),
       arguments.getOptionalEnumList(ISSUE_STATUSES_PROPERTY, VALID_ISSUE_STATUSES),

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
@@ -17,9 +17,11 @@
 package org.sonarsource.sonarqube.mcp.tools.issues;
 
 import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.issues.IssuesApi;
 import org.sonarsource.sonarqube.mcp.serverapi.issues.response.SearchResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -29,8 +31,9 @@ public class SearchIssuesTool extends Tool {
   public static final String TOOL_NAME = "search_sonar_issues_in_projects";
 
   public static final String PROJECTS_PROPERTY = "projects";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String FILES_PROPERTY = "files";
-  public static final String PULL_REQUEST_ID_PROPERTY = "pullRequestId";
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
   public static final String SEVERITIES_PROPERTY = "severities";
   public static final String IMPACT_SOFTWARE_QUALITIES_PROPERTY = "impactSoftwareQualities";
   public static final String ISSUE_STATUSES_PROPERTY = "issueStatuses";
@@ -61,7 +64,8 @@ public class SearchIssuesTool extends Tool {
       .setDescription(description)
       .addArrayProperty(PROJECTS_PROPERTY, "string", "An optional list of Sonar projects to look in")
       .addArrayProperty(FILES_PROPERTY, "string", "An optional list of component keys (files, directories, modules) to filter issues")
-      .addStringProperty(PULL_REQUEST_ID_PROPERTY, "The identifier of the Pull Request to look in")
+      .addBranchProperty()
+      .addPullRequestProperty()
       .addEnumProperty(SEVERITIES_PROPERTY, VALID_SEVERITIES, "An optional list of severities to filter by")
       .addEnumProperty(IMPACT_SOFTWARE_QUALITIES_PROPERTY, VALID_IMPACT_SOFTWARE_QUALITIES, "An optional list of software qualities to filter by")
       .addEnumProperty(ISSUE_STATUSES_PROPERTY, VALID_ISSUE_STATUSES, "An optional list of issue statuses to filter by. Note: IN_SANDBOX is valid only for SonarQube Server")
@@ -74,18 +78,26 @@ public class SearchIssuesTool extends Tool {
 
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
-    var searchParams = extractSearchParams(arguments);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
+    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
+
+    var searchParams = extractSearchParams(arguments, branch);
     var response = serverApiProvider.get().issuesApi().search(searchParams);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
   }
 
-  private static IssuesApi.SearchParams extractSearchParams(Tool.Arguments arguments) {
+  private static IssuesApi.SearchParams extractSearchParams(Tool.Arguments arguments, @Nullable String branch) {
     return new IssuesApi.SearchParams(
       arguments.getOptionalStringList(PROJECTS_PROPERTY),
-      null,
+      branch,
       arguments.getOptionalStringList(FILES_PROPERTY),
-      arguments.getOptionalString(PULL_REQUEST_ID_PROPERTY),
+      arguments.getOptionalString(PULL_REQUEST_PROPERTY),
       arguments.getOptionalEnumList(SEVERITIES_PROPERTY, VALID_SEVERITIES),
       arguments.getOptionalEnumList(IMPACT_SOFTWARE_QUALITIES_PROPERTY, VALID_IMPACT_SOFTWARE_QUALITIES),
       arguments.getOptionalEnumList(ISSUE_STATUSES_PROPERTY, VALID_ISSUE_STATUSES),

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
@@ -43,9 +43,8 @@ public class GetComponentMeasuresTool extends Tool {
       .setTitle("Get SonarQube Project Measures")
       .setDescription("Get SonarQube measures for a project, such as ncloc, complexity, violations, coverage, etc.")
       .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "The project key", configuredProjectKey)
-      .addBranchProperty()
+      .addBranchAndPullRequestProperties()
       .addArrayProperty(METRIC_KEYS_PROPERTY, "string", "The metric keys to retrieve (e.g. ncloc, complexity, violations, coverage)")
-      .addPullRequestProperty()
       .setReadOnlyHint()
       .build(),
       ToolCategory.MEASURES);
@@ -56,16 +55,16 @@ public class GetComponentMeasuresTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var component = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
     var metricKeys = arguments.getOptionalStringList(METRIC_KEYS_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
 
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
-    var response = serverApiProvider.get().measuresApi().getComponentMeasures(component, branch, metricKeys, pullRequest);
+    var response = serverApiProvider.get().measuresApi().getComponentMeasures(
+      component, branchPullRequest.branch(), metricKeys, branchPullRequest.pullRequest());
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.response.ComponentMeasuresResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -28,8 +29,9 @@ public class GetComponentMeasuresTool extends Tool {
 
   public static final String TOOL_NAME = "get_component_measures";
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String METRIC_KEYS_PROPERTY = "metricKeys";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;
   @Nullable
@@ -41,8 +43,9 @@ public class GetComponentMeasuresTool extends Tool {
       .setTitle("Get SonarQube Project Measures")
       .setDescription("Get SonarQube measures for a project, such as ncloc, complexity, violations, coverage, etc.")
       .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "The project key", configuredProjectKey)
+      .addBranchProperty()
       .addArrayProperty(METRIC_KEYS_PROPERTY, "string", "The metric keys to retrieve (e.g. ncloc, complexity, violations, coverage)")
-      .addStringProperty(PULL_REQUEST_PROPERTY, "The pull request identifier to analyze for measures")
+      .addPullRequestProperty()
       .setReadOnlyHint()
       .build(),
       ToolCategory.MEASURES);
@@ -53,10 +56,16 @@ public class GetComponentMeasuresTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var component = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var metricKeys = arguments.getOptionalStringList(METRIC_KEYS_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
 
-    var response = serverApiProvider.get().measuresApi().getComponentMeasures(component, null, metricKeys, pullRequest);
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
+
+    var response = serverApiProvider.get().measuresApi().getComponentMeasures(component, branch, metricKeys, pullRequest);
     var toolResponse = buildStructuredContent(response);
     return Tool.Result.success(toolResponse);
   }
@@ -97,4 +106,4 @@ public class GetComponentMeasuresTool extends Tool {
     return new GetComponentMeasuresToolResponse(componentResponse, measures, metrics);
   }
 
-} 
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/SearchFilesByCoverageTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/SearchFilesByCoverageTool.java
@@ -24,6 +24,7 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.ComponentTreeParams;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.response.ComponentMeasuresResponse;
 import org.sonarsource.sonarqube.mcp.serverapi.measures.response.ComponentTreeResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -32,7 +33,8 @@ public class SearchFilesByCoverageTool extends Tool {
 
   public static final String TOOL_NAME = "search_files_by_coverage";
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
   public static final String MAX_COVERAGE_PROPERTY = "maxCoverage";
   public static final String PAGE_INDEX_PROPERTY = "pageIndex";
   public static final String PAGE_SIZE_PROPERTY = "pageSize";
@@ -53,7 +55,8 @@ public class SearchFilesByCoverageTool extends Tool {
         .setDescription("Search for files in a project sorted by coverage (ascending - worst coverage first). " +
           "This tool helps identify files that need test coverage improvements.")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "The project key to search in", configuredProjectKey)
-        .addStringProperty(PULL_REQUEST_PROPERTY, "Pull request id to analyze")
+        .addBranchProperty()
+        .addPullRequestProperty()
         .addNumberProperty(MAX_COVERAGE_PROPERTY, "Only return files with coverage below this threshold (0-100)")
         .addNumberProperty(PAGE_INDEX_PROPERTY, "Page index (1-based, default: 1)")
         .addNumberProperty(PAGE_SIZE_PROPERTY, "Page size (default: 100, max: 500)")
@@ -67,10 +70,16 @@ public class SearchFilesByCoverageTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
     var maxCoverage = arguments.getOptionalInteger(MAX_COVERAGE_PROPERTY);
     var pageIndex = arguments.getOptionalInteger(PAGE_INDEX_PROPERTY);
     var pageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
+
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
 
     if (maxCoverage != null && (maxCoverage < 0 || maxCoverage > 100)) {
       return Tool.Result.failure("maxCoverage must be between 0 and 100");
@@ -80,7 +89,7 @@ public class SearchFilesByCoverageTool extends Tool {
     var actualPageSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, 500) : 100;
 
     // First, get project-level metrics for summary
-    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, null,
+    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branch,
       List.of(METRIC_COVERAGE, METRIC_LINES_TO_COVER, METRIC_UNCOVERED_LINES), pullRequest
     );
 
@@ -91,7 +100,7 @@ public class SearchFilesByCoverageTool extends Tool {
 
     var params = new ComponentTreeParams(
       projectKey,
-      null,
+      branch,
       metricKeys,
       pullRequest,
       // Only files

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/SearchFilesByCoverageTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/SearchFilesByCoverageTool.java
@@ -55,8 +55,7 @@ public class SearchFilesByCoverageTool extends Tool {
         .setDescription("Search for files in a project sorted by coverage (ascending - worst coverage first). " +
           "This tool helps identify files that need test coverage improvements.")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, "The project key to search in", configuredProjectKey)
-        .addBranchProperty()
-        .addPullRequestProperty()
+        .addBranchAndPullRequestProperties()
         .addNumberProperty(MAX_COVERAGE_PROPERTY, "Only return files with coverage below this threshold (0-100)")
         .addNumberProperty(PAGE_INDEX_PROPERTY, "Page index (1-based, default: 1)")
         .addNumberProperty(PAGE_SIZE_PROPERTY, "Page size (default: 100, max: 500)")
@@ -70,15 +69,14 @@ public class SearchFilesByCoverageTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
     var maxCoverage = arguments.getOptionalInteger(MAX_COVERAGE_PROPERTY);
     var pageIndex = arguments.getOptionalInteger(PAGE_INDEX_PROPERTY);
     var pageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
 
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
     if (maxCoverage != null && (maxCoverage < 0 || maxCoverage > 100)) {
@@ -89,8 +87,8 @@ public class SearchFilesByCoverageTool extends Tool {
     var actualPageSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, 500) : 100;
 
     // First, get project-level metrics for summary
-    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branch,
-      List.of(METRIC_COVERAGE, METRIC_LINES_TO_COVER, METRIC_UNCOVERED_LINES), pullRequest
+    var projectMetrics = serverApiProvider.get().measuresApi().getComponentMeasures(projectKey, branchPullRequest.branch(),
+      List.of(METRIC_COVERAGE, METRIC_LINES_TO_COVER, METRIC_UNCOVERED_LINES), branchPullRequest.pullRequest()
     );
 
     // Then get the file tree with coverage metrics
@@ -100,9 +98,9 @@ public class SearchFilesByCoverageTool extends Tool {
 
     var params = new ComponentTreeParams(
       projectKey,
-      branch,
+      branchPullRequest.branch(),
       metricKeys,
-      pullRequest,
+      branchPullRequest.pullRequest(),
       // Only files
       "FIL",
       // All files in tree

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusTool.java
@@ -42,12 +42,11 @@ public class ProjectStatusTool extends Tool {
         Get the Quality Gate Status for a project. Either '%s', '%s' or '%s' must be provided.
         """.formatted(ANALYSIS_ID_PROPERTY, PROJECT_ID_PROPERTY, PROJECT_KEY_PROPERTY))
       .addStringProperty(ANALYSIS_ID_PROPERTY, "The optional analysis ID to get the status for, for example 'AU-TpxcA-iU5OvuD2FL1'")
-      .addBranchProperty()
+      .addBranchAndPullRequestProperties()
       .addStringProperty(PROJECT_ID_PROPERTY, """
         The optional project ID to get the status for, for example 'AU-Tpxb--iU5OvuD2FLy'. Doesn't work with branches or pull requests.
         """)
       .addStringProperty(PROJECT_KEY_PROPERTY, "The optional project key to get the status for, for example 'my_project'")
-      .addPullRequestProperty()
       .setReadOnlyHint()
       .build(),
       ToolCategory.QUALITY_GATES);
@@ -57,25 +56,25 @@ public class ProjectStatusTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var analysisId = arguments.getOptionalString(ANALYSIS_ID_PROPERTY);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
     var projectId = arguments.getOptionalString(PROJECT_ID_PROPERTY);
     var projectKey = arguments.getOptionalString(PROJECT_KEY_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
 
     if (analysisId == null && projectId == null && projectKey == null) {
       return Tool.Result.failure("Either '%s', '%s' or '%s' must be provided".formatted(ANALYSIS_ID_PROPERTY, PROJECT_ID_PROPERTY, PROJECT_KEY_PROPERTY));
     }
 
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
-    if (projectId != null && (branch != null || pullRequest != null)) {
+    if (projectId != null && (branchPullRequest.branch() != null || branchPullRequest.pullRequest() != null)) {
       return Tool.Result.failure("Project ID doesn't work with branches or pull requests");
     }
 
-    var projectStatus = serverApiProvider.get().qualityGatesApi().getProjectQualityGateStatus(analysisId, branch, projectId, projectKey, pullRequest);
+    var projectStatus = serverApiProvider.get().qualityGatesApi().getProjectQualityGateStatus(
+      analysisId, branchPullRequest.branch(), projectId, projectKey, branchPullRequest.pullRequest());
     var toolResponse = buildStructuredContent(projectStatus);
     return Tool.Result.success(toolResponse);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusTool.java
@@ -18,6 +18,7 @@ package org.sonarsource.sonarqube.mcp.tools.qualitygates;
 
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.qualitygates.response.ProjectStatusResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -26,9 +27,10 @@ public class ProjectStatusTool extends Tool {
 
   public static final String TOOL_NAME = "get_project_quality_gate_status";
   public static final String ANALYSIS_ID_PROPERTY = "analysisId";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String PROJECT_ID_PROPERTY = "projectId";
   public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;
 
@@ -40,11 +42,12 @@ public class ProjectStatusTool extends Tool {
         Get the Quality Gate Status for a project. Either '%s', '%s' or '%s' must be provided.
         """.formatted(ANALYSIS_ID_PROPERTY, PROJECT_ID_PROPERTY, PROJECT_KEY_PROPERTY))
       .addStringProperty(ANALYSIS_ID_PROPERTY, "The optional analysis ID to get the status for, for example 'AU-TpxcA-iU5OvuD2FL1'")
+      .addBranchProperty()
       .addStringProperty(PROJECT_ID_PROPERTY, """
-        The optional project ID to get the status for, for example 'AU-Tpxb--iU5OvuD2FLy'. Doesn't work with pull requests.
+        The optional project ID to get the status for, for example 'AU-Tpxb--iU5OvuD2FLy'. Doesn't work with branches or pull requests.
         """)
       .addStringProperty(PROJECT_KEY_PROPERTY, "The optional project key to get the status for, for example 'my_project'")
-      .addStringProperty(PULL_REQUEST_PROPERTY, "The optional pull request ID to get the status for, for example '5461'")
+      .addPullRequestProperty()
       .setReadOnlyHint()
       .build(),
       ToolCategory.QUALITY_GATES);
@@ -54,6 +57,7 @@ public class ProjectStatusTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var analysisId = arguments.getOptionalString(ANALYSIS_ID_PROPERTY);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var projectId = arguments.getOptionalString(PROJECT_ID_PROPERTY);
     var projectKey = arguments.getOptionalString(PROJECT_KEY_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
@@ -62,11 +66,16 @@ public class ProjectStatusTool extends Tool {
       return Tool.Result.failure("Either '%s', '%s' or '%s' must be provided".formatted(ANALYSIS_ID_PROPERTY, PROJECT_ID_PROPERTY, PROJECT_KEY_PROPERTY));
     }
 
-    if (projectId != null && pullRequest != null) {
-      return Tool.Result.failure("Project ID doesn't work with pull requests");
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
     }
 
-    var projectStatus = serverApiProvider.get().qualityGatesApi().getProjectQualityGateStatus(analysisId, null, projectId, projectKey, pullRequest);
+    if (projectId != null && (branch != null || pullRequest != null)) {
+      return Tool.Result.failure("Project ID doesn't work with branches or pull requests");
+    }
+
+    var projectStatus = serverApiProvider.get().qualityGatesApi().getProjectQualityGateStatus(analysisId, branch, projectId, projectKey, pullRequest);
     var toolResponse = buildStructuredContent(projectStatus);
     return Tool.Result.success(toolResponse);
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetFileCoverageDetailsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetFileCoverageDetailsTool.java
@@ -19,6 +19,7 @@ package org.sonarsource.sonarqube.mcp.tools.sources;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.sources.response.SourceLinesResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -27,7 +28,8 @@ public class GetFileCoverageDetailsTool extends Tool {
 
   public static final String TOOL_NAME = "get_file_coverage_details";
   public static final String KEY_PROPERTY = "key";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;
 
@@ -40,7 +42,8 @@ public class GetFileCoverageDetailsTool extends Tool {
           "This tool helps identify precisely where to add test coverage. " +
           "Use after identifying files with low coverage via search_files_by_coverage.")
         .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.java)")
-        .addStringProperty(PULL_REQUEST_PROPERTY, "Pull request id")
+        .addBranchProperty()
+        .addPullRequestProperty()
         .setReadOnlyHint()
         .build(),
       ToolCategory.COVERAGE);
@@ -50,10 +53,16 @@ public class GetFileCoverageDetailsTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
 
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
+
     try {
-      var sourceLinesResponse = serverApiProvider.get().sourcesApi().getSourceLines(key, null, pullRequest, null, null);
+      var sourceLinesResponse = serverApiProvider.get().sourcesApi().getSourceLines(key, branch, pullRequest, null, null);
 
       // Extract file path from key (after the colon)
       var filePath = key.contains(":") ? key.substring(key.indexOf(':') + 1) : null;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetFileCoverageDetailsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetFileCoverageDetailsTool.java
@@ -42,8 +42,7 @@ public class GetFileCoverageDetailsTool extends Tool {
           "This tool helps identify precisely where to add test coverage. " +
           "Use after identifying files with low coverage via search_files_by_coverage.")
         .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.java)")
-        .addBranchProperty()
-        .addPullRequestProperty()
+        .addBranchAndPullRequestProperties()
         .setReadOnlyHint()
         .build(),
       ToolCategory.COVERAGE);
@@ -53,16 +52,15 @@ public class GetFileCoverageDetailsTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
-
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
 
     try {
-      var sourceLinesResponse = serverApiProvider.get().sourcesApi().getSourceLines(key, branch, pullRequest, null, null);
+      var sourceLinesResponse = serverApiProvider.get().sourcesApi().getSourceLines(
+        key, branchPullRequest.branch(), branchPullRequest.pullRequest(), null, null);
 
       // Extract file path from key (after the colon)
       var filePath = key.contains(":") ? key.substring(key.indexOf(':') + 1) : null;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetRawSourceTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetRawSourceTool.java
@@ -37,8 +37,7 @@ public class GetRawSourceTool extends Tool {
       .setTitle("Get SonarQube Raw Source Code")
       .setDescription("Get source code as raw text. Requires 'See Source Code' permission on file.")
       .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.php)")
-      .addBranchProperty()
-      .addPullRequestProperty()
+      .addBranchAndPullRequestProperties()
       .setReadOnlyHint()
       .build(),
       ToolCategory.SOURCES);
@@ -48,16 +47,14 @@ public class GetRawSourceTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
-    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
-    var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
-
-    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
-    if (mutualExclusionError.isPresent()) {
-      return mutualExclusionError.get();
+    var branchPullRequest = BranchPullRequestContext.from(arguments);
+    var validationError = branchPullRequest.validationError();
+    if (validationError.isPresent()) {
+      return validationError.get();
     }
-    
+
     try {
-      var rawSource = serverApiProvider.get().sourcesApi().getRawSource(key, branch, pullRequest);
+      var rawSource = serverApiProvider.get().sourcesApi().getRawSource(key, branchPullRequest.branch(), branchPullRequest.pullRequest());
       var response = new GetRawSourceToolResponse(key, rawSource);
       return Tool.Result.success(response);
     } catch (Exception e) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetRawSourceTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/sources/GetRawSourceTool.java
@@ -17,6 +17,7 @@
 package org.sonarsource.sonarqube.mcp.tools.sources;
 
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -25,7 +26,8 @@ public class GetRawSourceTool extends Tool {
 
   public static final String TOOL_NAME = "get_raw_source";
   public static final String KEY_PROPERTY = "key";
-  public static final String PULL_REQUEST_PROPERTY = "pullRequest";
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;
 
@@ -35,7 +37,8 @@ public class GetRawSourceTool extends Tool {
       .setTitle("Get SonarQube Raw Source Code")
       .setDescription("Get source code as raw text. Requires 'See Source Code' permission on file.")
       .addRequiredStringProperty(KEY_PROPERTY, "File key (e.g. my_project:src/foo/Bar.php)")
-      .addStringProperty(PULL_REQUEST_PROPERTY, "Pull request id")
+      .addBranchProperty()
+      .addPullRequestProperty()
       .setReadOnlyHint()
       .build(),
       ToolCategory.SOURCES);
@@ -45,10 +48,16 @@ public class GetRawSourceTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
+    var branch = arguments.getOptionalString(BRANCH_PROPERTY);
     var pullRequest = arguments.getOptionalString(PULL_REQUEST_PROPERTY);
+
+    var mutualExclusionError = BranchPullRequestContext.validateMutualExclusion(branch, pullRequest);
+    if (mutualExclusionError.isPresent()) {
+      return mutualExclusionError.get();
+    }
     
     try {
-      var rawSource = serverApiProvider.get().sourcesApi().getRawSource(key, null, pullRequest);
+      var rawSource = serverApiProvider.get().sourcesApi().getRawSource(key, branch, pullRequest);
       var response = new GetRawSourceToolResponse(key, rawSource);
       return Tool.Result.success(response);
     } catch (Exception e) {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContextTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContextTest.java
@@ -1,0 +1,48 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BranchPullRequestContextTest {
+
+  @Test
+  void validateMutualExclusion_should_return_empty_when_both_are_null() {
+    assertThat(BranchPullRequestContext.validateMutualExclusion(null, null)).isEmpty();
+  }
+
+  @Test
+  void validateMutualExclusion_should_return_empty_when_only_branch_is_set() {
+    assertThat(BranchPullRequestContext.validateMutualExclusion("main", null)).isEmpty();
+  }
+
+  @Test
+  void validateMutualExclusion_should_return_empty_when_only_pull_request_is_set() {
+    assertThat(BranchPullRequestContext.validateMutualExclusion(null, "5461")).isEmpty();
+  }
+
+  @Test
+  void validateMutualExclusion_should_return_error_when_both_are_set() {
+    var result = BranchPullRequestContext.validateMutualExclusion("main", "5461");
+
+    assertThat(result).isPresent();
+    assertThat(result.get().isError()).isTrue();
+  }
+
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContextTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContextTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.sonarqube.mcp.tools;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +44,26 @@ class BranchPullRequestContextTest {
 
     assertThat(result).isPresent();
     assertThat(result.get().isError()).isTrue();
+  }
+
+  @Test
+  void params_from_should_extract_branch_and_pull_request() {
+    var arguments = new Tool.Arguments(Map.of(
+      BranchPullRequestContext.BRANCH_PROPERTY, "develop",
+      BranchPullRequestContext.PULL_REQUEST_PROPERTY, "42"), null);
+
+    var params = BranchPullRequestContext.from(arguments);
+
+    assertThat(params.branch()).isEqualTo("develop");
+    assertThat(params.pullRequest()).isEqualTo("42");
+    assertThat(params.validationError()).isPresent();
+  }
+
+  @Test
+  void params_validationError_should_return_empty_when_only_branch_is_set() {
+    var arguments = new Tool.Arguments(Map.of(BranchPullRequestContext.BRANCH_PROPERTY, "main"), null);
+
+    assertThat(BranchPullRequestContext.from(arguments).validationError()).isEmpty();
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
@@ -1,0 +1,218 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools.branches;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import com.github.tomakehurst.wiremock.http.Body;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.sonarsource.sonarqube.mcp.harness.ReceivedRequest;
+import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTest;
+import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTestHarness;
+import org.sonarsource.sonarqube.mcp.serverapi.branches.ProjectBranchesApi;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpTestClient.assertResultEquals;
+import static org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpTestClient.assertSchemaEquals;
+
+class ListBranchesToolTests {
+
+  @SonarQubeMcpServerTest
+  void it_should_validate_output_schema_and_annotations(SonarQubeMcpServerTestHarness harness) {
+    var mcpClient = harness.newClient();
+
+    var tool = mcpClient.listTools().stream().filter(t -> t.name().equals(ListBranchesTool.TOOL_NAME)).findFirst().orElseThrow();
+
+    assertThat(tool.annotations()).isNotNull();
+    assertThat(tool.annotations().readOnlyHint()).isTrue();
+    assertThat(tool.annotations().openWorldHint()).isTrue();
+
+    assertSchemaEquals(tool.outputSchema(), """
+      {
+         "type":"object",
+         "properties":{
+            "projectKey":{
+               "description":"Project key",
+               "type":"string"
+            },
+            "totalBranches":{
+               "description":"Total number of branches",
+               "type":"integer"
+            },
+            "branches":{
+               "description":"List of branches for this project",
+               "type":"array",
+               "items":{
+                  "type":"object",
+                  "properties":{
+                     "name":{
+                        "type":"string",
+                        "description":"Branch name that can be used with other tools as the branch parameter"
+                     },
+                     "isMain":{
+                        "type":"boolean",
+                        "description":"Whether this is the main branch"
+                     },
+                     "type":{
+                        "type":"string",
+                        "description":"Branch type in SonarQube"
+                     },
+                     "qualityGateStatus":{
+                        "type":"string",
+                        "description":"Quality gate status for this branch"
+                     },
+                     "analysisDate":{
+                        "type":"string",
+                        "description":"Date of the last analysis"
+                     },
+                     "branchId":{
+                        "type":"string",
+                        "description":"Internal branch identifier"
+                     }
+                  },
+                  "required":[
+                     "isMain",
+                     "name"
+                  ]
+               }
+            }
+         },
+         "required":[
+            "branches",
+            "projectKey",
+            "totalBranches"
+         ]
+      }
+      """);
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_return_an_error_if_the_request_fails_due_to_token_permission(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withStatus(403)));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
+
+    assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent("An error occurred during the tool execution: SonarQube answered with Forbidden. Please verify your token has the required permissions for this operation.").build());
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_return_empty_message_when_no_branches(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withResponseBody(
+        Body.fromJsonBytes(generateEmptyBranchesResponse().getBytes(StandardCharsets.UTF_8))
+      )));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
+
+    assertResultEquals(result, """
+      {
+        "projectKey" : "my_project",
+        "totalBranches" : 0,
+        "branches" : [ ]
+      }""");
+    assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+      .contains(new ReceivedRequest("Bearer token", ""));
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_list_branches(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withResponseBody(
+        Body.fromJsonBytes(generateBranchesResponse().getBytes(StandardCharsets.UTF_8))
+      )));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
+
+    assertResultEquals(result, """
+      {
+        "projectKey" : "my_project",
+        "totalBranches" : 2,
+        "branches" : [ {
+          "name" : "develop",
+          "isMain" : false,
+          "type" : "BRANCH",
+          "qualityGateStatus" : "OK",
+          "analysisDate" : "2017-04-03T13:37:00+0100",
+          "branchId" : "ac312cc6-26a2-4e2c-9eff-1072358f2017"
+        }, {
+          "name" : "main",
+          "isMain" : true,
+          "type" : "BRANCH",
+          "qualityGateStatus" : "ERROR",
+          "analysisDate" : "2017-04-01T01:15:42+0100",
+          "branchId" : "57f02458-65db-4e7f-a144-20122af12a4c"
+        } ]
+      }""");
+    assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+      .contains(new ReceivedRequest("Bearer token", ""));
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_handle_server_error_response(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withStatus(500)));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
+
+    assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent("An error occurred during the tool execution: SonarQube answered with Error 500 on " + harness.getMockSonarQubeServer().baseUrl() + "/api/project_branches/list?project=my_project").build());
+  }
+
+  private static String generateEmptyBranchesResponse() {
+    return """
+      {
+        "branches": []
+      }
+      """;
+  }
+
+  private static String generateBranchesResponse() {
+    return """
+      {
+        "branches": [
+          {
+            "name": "develop",
+            "isMain": false,
+            "type": "BRANCH",
+            "status": {
+              "qualityGateStatus": "OK"
+            },
+            "analysisDate": "2017-04-03T13:37:00+0100",
+            "branchId": "ac312cc6-26a2-4e2c-9eff-1072358f2017"
+          },
+          {
+            "name": "main",
+            "isMain": true,
+            "type": "BRANCH",
+            "status": {
+              "qualityGateStatus": "ERROR"
+            },
+            "analysisDate": "2017-04-01T01:15:42+0100",
+            "branchId": "57f02458-65db-4e7f-a144-20122af12a4c"
+          }
+        ]
+      }
+      """;
+  }
+
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
@@ -72,7 +72,7 @@ class ListBranchesToolTests {
                      "type":{
                         "type":"string",
                         "enum":["LONG","SHORT","BRANCH"],
-                        "description":"Branch type in SonarQube (LONG on SonarCloud, BRANCH on SonarQube Server)"
+                        "description":"Branch type in SonarQube (LONG on SonarQube Cloud, BRANCH on SonarQube Server)"
                      },
                      "qualityGateStatus":{
                         "type":"string",

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
@@ -71,10 +71,12 @@ class ListBranchesToolTests {
                      },
                      "type":{
                         "type":"string",
-                        "description":"Branch type in SonarQube"
+                        "enum":["LONG","SHORT","BRANCH"],
+                        "description":"Branch type in SonarQube (LONG on SonarCloud, BRANCH on SonarQube Server)"
                      },
                      "qualityGateStatus":{
                         "type":"string",
+                        "enum":["OK","ERROR","WARN","NONE"],
                         "description":"Quality gate status for this branch"
                      },
                      "analysisDate":{
@@ -87,6 +89,7 @@ class ListBranchesToolTests {
                      }
                   },
                   "required":[
+                     "branchId",
                      "isMain",
                      "name"
                   ]
@@ -134,10 +137,10 @@ class ListBranchesToolTests {
   }
 
   @SonarQubeMcpServerTest
-  void it_should_list_branches(SonarQubeMcpServerTestHarness harness) {
+  void it_should_list_long_lived_branches_for_sonarqube_server(SonarQubeMcpServerTestHarness harness) {
     harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
       .willReturn(aResponse().withResponseBody(
-        Body.fromJsonBytes(generateBranchesResponse().getBytes(StandardCharsets.UTF_8))
+        Body.fromJsonBytes(generateSonarQubeServerBranchesResponse().getBytes(StandardCharsets.UTF_8))
       )));
     var mcpClient = harness.newClient();
 
@@ -168,6 +171,31 @@ class ListBranchesToolTests {
   }
 
   @SonarQubeMcpServerTest
+  void it_should_filter_short_branches_on_sonarcloud(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withResponseBody(
+        Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
+      )));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
+
+    assertResultEquals(result, """
+      {
+        "projectKey" : "my_project",
+        "totalBranches" : 1,
+        "branches" : [ {
+          "name" : "master",
+          "isMain" : true,
+          "type" : "LONG",
+          "qualityGateStatus" : "ERROR",
+          "analysisDate" : "2017-04-01T01:15:42+0100",
+          "branchId" : "88471269-96e8-47f8-8c7d-e40e729f1373"
+        } ]
+      }""");
+  }
+
+  @SonarQubeMcpServerTest
   void it_should_handle_server_error_response(SonarQubeMcpServerTestHarness harness) {
     harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
       .willReturn(aResponse().withStatus(500)));
@@ -186,7 +214,7 @@ class ListBranchesToolTests {
       """;
   }
 
-  private static String generateBranchesResponse() {
+  private static String generateSonarQubeServerBranchesResponse() {
     return """
       {
         "branches": [
@@ -209,6 +237,39 @@ class ListBranchesToolTests {
             },
             "analysisDate": "2017-04-01T01:15:42+0100",
             "branchId": "57f02458-65db-4e7f-a144-20122af12a4c"
+          }
+        ]
+      }
+      """;
+  }
+
+  private static String generateSonarCloudBranchesResponse() {
+    return """
+      {
+        "branches": [
+          {
+            "name": "feature/foo",
+            "isMain": false,
+            "type": "SHORT",
+            "mergeBranch": "master",
+            "status": {
+              "qualityGateStatus": "OK",
+              "bugs": 1,
+              "vulnerabilities": 0,
+              "codeSmells": 0
+            },
+            "analysisDate": "2017-08-03T13:37:00+0100",
+            "branchId": "93cb33a1-b3dd-4226-b0a0-1d74e4dec194"
+          },
+          {
+            "name": "master",
+            "isMain": true,
+            "type": "LONG",
+            "status": {
+              "qualityGateStatus": "ERROR"
+            },
+            "analysisDate": "2017-04-01T01:15:42+0100",
+            "branchId": "88471269-96e8-47f8-8c7d-e40e729f1373"
           }
         ]
       }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksToolTests.java
@@ -317,7 +317,7 @@ class SearchDependencyRisksToolTests {
 
       var result = mcpClient.callTool(SearchDependencyRisksTool.TOOL_NAME, Map.of(
         SearchDependencyRisksTool.PROJECT_KEY_PROPERTY, "my-project",
-        SearchDependencyRisksTool.BRANCH_KEY_PROPERTY, "feature/new-feature"));
+        SearchDependencyRisksTool.BRANCH_PROPERTY, "feature/new-feature"));
 
       assertResultEquals(result, """
         {
@@ -371,7 +371,7 @@ class SearchDependencyRisksToolTests {
 
       var result = mcpClient.callTool(SearchDependencyRisksTool.TOOL_NAME, Map.of(
         SearchDependencyRisksTool.PROJECT_KEY_PROPERTY, "my-project",
-        SearchDependencyRisksTool.PULL_REQUEST_KEY_PROPERTY, "123"));
+        SearchDependencyRisksTool.PULL_REQUEST_PROPERTY, "123"));
 
       assertResultEquals(result, """
         {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
@@ -828,7 +828,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PULL_REQUEST_ID_PROPERTY, "5461"));
+        Map.of(SearchIssuesTool.PULL_REQUEST_PROPERTY, "5461"));
 
       assertResultEquals(result, """
         {
@@ -899,7 +899,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of("pullRequestId", "1"));
+        Map.of("pullRequest", "1"));
 
       assertResultEquals(result, """
         {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
@@ -303,6 +303,72 @@ class GetComponentMeasuresToolTests {
     }
 
     @SonarQubeMcpServerTest
+    void it_should_fetch_component_measures_with_branch(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH + "?component=" + urlEncode("MY_PROJECT:ElementImpl.java") + "&branch=main&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes(generateComponentMeasuresResponse().getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"
+      ));
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(
+          GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT:ElementImpl.java",
+          GetComponentMeasuresTool.BRANCH_PROPERTY, "main"
+        ));
+
+      assertResultEquals(result, """
+        {
+          "component" : {
+            "key" : "MY_PROJECT:ElementImpl.java",
+            "name" : "ElementImpl.java",
+            "qualifier" : "FIL",
+            "description" : "Implementation of Element interface",
+            "language" : "java",
+            "path" : "src/main/java/com/sonarsource/markdown/impl/ElementImpl.java"
+          },
+          "measures" : [ {
+            "metric" : "complexity",
+            "value" : "12"
+          }, {
+            "metric" : "new_violations"
+          }, {
+            "metric" : "ncloc",
+            "value" : "114"
+          } ],
+          "metrics" : [ {
+            "key" : "complexity",
+            "name" : "Complexity",
+            "description" : "Cyclomatic complexity",
+            "domain" : "Complexity",
+            "type" : "INT",
+            "hidden" : false,
+            "custom" : false
+          }, {
+            "key" : "ncloc",
+            "name" : "Lines of code",
+            "description" : "Non Commenting Lines of Code",
+            "domain" : "Size",
+            "type" : "INT",
+            "hidden" : false,
+            "custom" : false
+          }, {
+            "key" : "new_violations",
+            "name" : "New issues",
+            "description" : "New Issues",
+            "domain" : "Issues",
+            "type" : "INT",
+            "hidden" : false,
+            "custom" : false
+          } ]
+        }""");
+      assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+        .contains(new ReceivedRequest("Bearer token", ""));
+    }
+
+    @SonarQubeMcpServerTest
     void it_should_fetch_component_measures_with_metric_keys(SonarQubeMcpServerTestHarness harness) {
       harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH + "?component=" + urlEncode("MY_PROJECT:ElementImpl.java") + "&metricKeys=ncloc,complexity&additionalFields=metrics")
         .willReturn(aResponse().withResponseBody(
@@ -650,6 +716,72 @@ class GetComponentMeasuresToolTests {
       var result = mcpClient.callTool(
         GetComponentMeasuresTool.TOOL_NAME,
         Map.of(GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT:ElementImpl.java"));
+
+      assertResultEquals(result, """
+        {
+          "component" : {
+            "key" : "MY_PROJECT:ElementImpl.java",
+            "name" : "ElementImpl.java",
+            "qualifier" : "FIL",
+            "description" : "Implementation of Element interface",
+            "language" : "java",
+            "path" : "src/main/java/com/sonarsource/markdown/impl/ElementImpl.java"
+          },
+          "measures" : [ {
+            "metric" : "complexity",
+            "value" : "12"
+          }, {
+            "metric" : "new_violations"
+          }, {
+            "metric" : "ncloc",
+            "value" : "114"
+          } ],
+          "metrics" : [ {
+            "key" : "complexity",
+            "name" : "Complexity",
+            "description" : "Cyclomatic complexity",
+            "domain" : "Complexity",
+            "type" : "INT",
+            "hidden" : false,
+            "custom" : false
+          }, {
+            "key" : "ncloc",
+            "name" : "Lines of code",
+            "description" : "Non Commenting Lines of Code",
+            "domain" : "Size",
+            "type" : "INT",
+            "hidden" : false,
+            "custom" : false
+          }, {
+            "key" : "new_violations",
+            "name" : "New issues",
+            "description" : "New Issues",
+            "domain" : "Issues",
+            "type" : "INT",
+            "hidden" : false,
+            "custom" : false
+          } ]
+        }""");
+      assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+        .contains(new ReceivedRequest("Bearer token", ""));
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_fetch_component_measures_with_branch(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH + "?component=" + urlEncode("MY_PROJECT:ElementImpl.java") + "&branch=main&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes(generateComponentMeasuresResponse().getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"
+      ));
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(
+          GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT:ElementImpl.java",
+          GetComponentMeasuresTool.BRANCH_PROPERTY, "main"
+        ));
 
       assertResultEquals(result, """
         {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusToolTests.java
@@ -135,7 +135,35 @@ class ProjectStatusToolTests {
         ProjectStatusTool.TOOL_NAME,
         Map.of(ProjectStatusTool.PROJECT_ID_PROPERTY, "123", ProjectStatusTool.PULL_REQUEST_PROPERTY, "5461"));
 
-      assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent("Project ID doesn't work with pull requests").build());
+      assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent("Project ID doesn't work with branches or pull requests").build());
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_show_error_when_project_id_and_branch_are_provided(SonarQubeMcpServerTestHarness harness) {
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      var result = mcpClient.callTool(
+        ProjectStatusTool.TOOL_NAME,
+        Map.of(ProjectStatusTool.PROJECT_ID_PROPERTY, "123", ProjectStatusTool.BRANCH_PROPERTY, "main"));
+
+      assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent("Project ID doesn't work with branches or pull requests").build());
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_show_error_when_branch_and_pull_request_are_provided(SonarQubeMcpServerTestHarness harness) {
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      var result = mcpClient.callTool(
+        ProjectStatusTool.TOOL_NAME,
+        Map.of(
+          ProjectStatusTool.PROJECT_KEY_PROPERTY, "pkey",
+          ProjectStatusTool.BRANCH_PROPERTY, "main",
+          ProjectStatusTool.PULL_REQUEST_PROPERTY, "5461"));
+
+      assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent(
+        "Cannot use 'branch' and 'pullRequest' together. Use 'branch' for long-lived branches (see list_branches) or 'pullRequest' for pull requests (see list_pull_requests).").build());
     }
 
     @SonarQubeMcpServerTest
@@ -163,6 +191,59 @@ class ProjectStatusToolTests {
       var result = mcpClient.callTool(
         ProjectStatusTool.TOOL_NAME,
         Map.of(ProjectStatusTool.PROJECT_KEY_PROPERTY, "pkey"));
+
+      assertResultEquals(result, """
+        {
+          "status" : "ERROR",
+          "conditions" : [ {
+            "metricKey" : "new_coverage",
+            "status" : "ERROR",
+            "errorThreshold" : "85",
+            "actualValue" : "82.50562381034781"
+          }, {
+            "metricKey" : "new_blocker_violations",
+            "status" : "ERROR",
+            "errorThreshold" : "0",
+            "actualValue" : "14"
+          }, {
+            "metricKey" : "new_critical_violations",
+            "status" : "ERROR",
+            "errorThreshold" : "0",
+            "actualValue" : "1"
+          }, {
+            "metricKey" : "new_sqale_debt_ratio",
+            "status" : "OK",
+            "errorThreshold" : "5",
+            "actualValue" : "0.6562109862671661"
+          }, {
+            "metricKey" : "reopened_issues",
+            "status" : "OK",
+            "actualValue" : "0"
+          }, {
+            "metricKey" : "open_issues",
+            "status" : "ERROR",
+            "actualValue" : "17"
+          }, {
+            "metricKey" : "skipped_tests",
+            "status" : "OK",
+            "actualValue" : "0"
+          } ]
+        }""");
+      assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+        .contains(new ReceivedRequest("Bearer token", ""));
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_return_the_project_status_with_project_key_and_branch(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(QualityGatesApi.PROJECT_STATUS_PATH + "?branch=" + urlEncode("develop") + "&projectKey=pkey")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes(generatePayload().getBytes(StandardCharsets.UTF_8)))));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      var result = mcpClient.callTool(
+        ProjectStatusTool.TOOL_NAME,
+        Map.of(ProjectStatusTool.PROJECT_KEY_PROPERTY, "pkey", ProjectStatusTool.BRANCH_PROPERTY, "develop"));
 
       assertResultEquals(result, """
         {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/sources/GetRawSourceToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/sources/GetRawSourceToolTests.java
@@ -275,6 +275,47 @@ class GetRawSourceToolTests {
         .contains(new ReceivedRequest("Bearer token", ""));
     }
 
+    @SonarQubeMcpServerTest
+    void it_should_return_raw_source_code_with_branch_parameter(SonarQubeMcpServerTestHarness harness) {
+      var sourceCode = """
+        package org.sonar.check;
+
+        public enum Priority {
+          BLOCKER, CRITICAL, MAJOR, MINOR, INFO
+        }
+        """;
+
+      harness.getMockSonarQubeServer().stubFor(get(SourcesApi.SOURCES_RAW_PATH + "?key=" + urlEncode("my_project:src/foo/Bar.php") + "&branch=" + urlEncode("develop"))
+        .willReturn(aResponse().withBody(sourceCode)));
+      var mcpClient = harness.newClient();
+
+      var result = mcpClient.callTool(
+        GetRawSourceTool.TOOL_NAME,
+        Map.of("key", "my_project:src/foo/Bar.php", GetRawSourceTool.BRANCH_PROPERTY, "develop"));
+
+      assertResultEquals(result, """
+        {
+          "fileKey" : "my_project:src/foo/Bar.php",
+          "sourceCode" : "<?php\n"
+        }""".replace("<?php\n", sourceCode));
+      assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+        .contains(new ReceivedRequest("Bearer token", ""));
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_show_error_when_branch_and_pull_request_are_provided(SonarQubeMcpServerTestHarness harness) {
+      var mcpClient = harness.newClient();
+
+      var result = mcpClient.callTool(
+        GetRawSourceTool.TOOL_NAME,
+        Map.of(
+          "key", "my_project:src/foo/Bar.php",
+          GetRawSourceTool.BRANCH_PROPERTY, "develop",
+          "pullRequest", "5461"));
+
+      assertThat(result.isError()).isTrue();
+    }
+
   }
 
-} 
+}


### PR DESCRIPTION

<img width="754" height="1064" alt="image" src="https://github.com/user-attachments/assets/a9f6989a-7637-41db-a28b-b09629421090" />

----
## Summary by Gitar

- **New tool and API:**
  - Added `list_branches` tool to discover valid long-lived branch names for a project.
  - Implemented `ProjectBranchesApi` to support branch listing via the SonarQube API.
- **Context management:**
  - Introduced `BranchPullRequestContext` to unify `branch` and `pullRequest` parameter handling.
  - Added `validateMutualExclusion` to ensure `branch` and `pullRequest` are not used simultaneously in tool executions.
- **Refactoring:**
  - Standardized parameter names across tools to use `branch` and `pullRequest` consistently.
  - Updated `SchemaToolBuilder` to include helper methods for adding branch and pull request properties.
- **Documentation:**
  - Updated `README.md`, `GEMINI.md`, and `POWER.md` to clarify the distinction between long-lived branches and pull requests.
  - Added automated instructions to the MCP server configuration for better agent guidance.

<sub>This will update automatically on new commits.</sub>