### PR TITLE
MCP-498 Treat blank optional MCP tool string arguments as absent

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.tools.exception.MissingRequiredArgumentException;
 
@@ -92,7 +93,8 @@ public abstract class Tool {
       }
       var arg = argumentsMap.get(argumentName);
       return switch (arg) {
-        case String string -> string;
+        case String string when !string.isBlank() -> string;
+        case String ignored -> throw new MissingRequiredArgumentException(argumentName);
         case null -> throw new MissingRequiredArgumentException(argumentName);
         default -> String.valueOf(arg);
       };
@@ -115,6 +117,7 @@ public abstract class Tool {
       var arg = argumentsMap.get(argumentName);
       return switch (arg) {
         case Integer integer -> integer;
+        case String string when string.isBlank() -> null;
         case String string -> Integer.parseInt(string);
         case null, default -> null;
       };
@@ -125,6 +128,7 @@ public abstract class Tool {
       var arg = argumentsMap.get(argumentName);
       return switch (arg) {
         case Boolean bool -> bool;
+        case String string when string.isBlank() -> null;
         case String string -> Boolean.parseBoolean(string);
         case null, default -> null;
       };
@@ -134,10 +138,9 @@ public abstract class Tool {
     public String getOptionalString(String argumentName) {
       var arg = argumentsMap.get(argumentName);
       if (arg instanceof String string) {
-        return string;
-      } else {
-        return null;
+        return string.isBlank() ? null : string;
       }
+      return null;
     }
 
     /**
@@ -148,7 +151,7 @@ public abstract class Tool {
      */
     public String getProjectKeyWithFallback(String argumentName, @Nullable String configuredDefault) {
       var fromArg = getOptionalString(argumentName);
-      if (fromArg != null && !fromArg.isBlank()) {
+      if (fromArg != null) {
         return fromArg;
       }
       if (configuredDefault != null && !configuredDefault.isBlank()) {
@@ -174,49 +177,39 @@ public abstract class Tool {
     }
 
     @Nullable
-    @SuppressWarnings("unchecked")
     public List<String> getOptionalStringList(String argumentName) {
-      return (List<String>) argumentsMap.get(argumentName);
+      var arg = argumentsMap.get(argumentName);
+      if (!(arg instanceof List<?> list)) {
+        return null;
+      }
+      var values = list.stream()
+        .filter(Objects::nonNull)
+        .map(String::valueOf)
+        .filter(value -> !value.isBlank())
+        .toList();
+      return values.isEmpty() ? null : values;
     }
 
     @Nullable
     public String getOptionalEnumValue(String argumentName, String[] validValues) {
-      var arg = argumentsMap.get(argumentName);
-      if (arg == null) {
+      var value = resolveEnumArgumentValue(argumentName);
+      if (value == null) {
         return null;
       }
-      
-      var value = switch (arg) {
-        case String string -> string;
-        case List<?> list when !list.isEmpty() -> String.valueOf(list.getFirst());
-        case List<?> ignored -> null;
-        default -> String.valueOf(arg);
-      };
-      
-      if (value != null && !isValidEnumValue(value, validValues)) {
+      if (!isValidEnumValue(value, validValues)) {
         throw new IllegalArgumentException("Invalid " + argumentName + ": " + value + ". Possible values: " + String.join(", ", validValues));
       }
-      
       return value;
     }
 
     public String getEnumOrThrow(String argumentName, String[] validValues) {
-      var arg = argumentsMap.get(argumentName);
-      if (arg == null) {
+      var value = resolveEnumArgumentValue(argumentName);
+      if (value == null) {
         throw new MissingRequiredArgumentException(argumentName);
       }
-      
-      var value = switch (arg) {
-        case String string -> string;
-        case List<?> list when !list.isEmpty() -> String.valueOf(list.getFirst());
-        case List<?> ignored -> throw new MissingRequiredArgumentException(argumentName);
-        default -> String.valueOf(arg);
-      };
-      
       if (!isValidEnumValue(value, validValues)) {
         throw new IllegalArgumentException("Invalid " + argumentName + ": " + value + ". Possible values: " + String.join(", ", validValues));
       }
-      
       return value;
     }
 
@@ -238,6 +231,21 @@ public abstract class Tool {
       return values;
     }
     
+
+    @Nullable
+    private String resolveEnumArgumentValue(String argumentName) {
+      var arg = argumentsMap.get(argumentName);
+      if (arg == null) {
+        return null;
+      }
+      var value = switch (arg) {
+        case String string -> string;
+        case List<?> list when !list.isEmpty() -> String.valueOf(list.getFirst());
+        case List<?> ignored -> null;
+        default -> String.valueOf(arg);
+      };
+      return value != null && value.isBlank() ? null : value;
+    }
 
     private static boolean isValidEnumValue(String value, String[] validValues) {
       for (var validValue : validValues) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
@@ -117,8 +117,7 @@ public abstract class Tool {
       var arg = argumentsMap.get(argumentName);
       return switch (arg) {
         case Integer integer -> integer;
-        case String string when string.isBlank() -> null;
-        case String string -> Integer.parseInt(string);
+        case String string when !string.isBlank() -> Integer.parseInt(string);
         case null, default -> null;
       };
     }
@@ -128,8 +127,7 @@ public abstract class Tool {
       var arg = argumentsMap.get(argumentName);
       return switch (arg) {
         case Boolean bool -> bool;
-        case String string when string.isBlank() -> null;
-        case String string -> Boolean.parseBoolean(string);
+        case String string when !string.isBlank() -> Boolean.parseBoolean(string);
         case null, default -> null;
       };
     }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolArgumentsTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolArgumentsTest.java
@@ -180,6 +180,86 @@ class ToolArgumentsTest {
   }
 
   @Test
+  void should_return_null_when_optional_string_argument_is_blank() {
+    var arguments = new Tool.Arguments(Map.of("blankArg", " ", "emptyArg", ""), null);
+
+    assertThat(arguments.getOptionalString("blankArg")).isNull();
+    assertThat(arguments.getOptionalString("emptyArg")).isNull();
+  }
+
+  @Test
+  void should_throw_exception_when_required_string_argument_is_blank() {
+    var arguments = new Tool.Arguments(Map.of("stringArg", ""), null);
+
+    assertThatThrownBy(() -> arguments.getStringOrThrow("stringArg"))
+      .isInstanceOf(MissingRequiredArgumentException.class)
+      .hasMessage("Missing required argument: stringArg");
+  }
+
+  @Test
+  void should_return_null_when_optional_integer_argument_is_blank_string() {
+    var arguments = new Tool.Arguments(Map.of("intArg", ""), null);
+
+    assertThat(arguments.getOptionalInteger("intArg")).isNull();
+  }
+
+  @Test
+  void should_return_null_when_optional_boolean_argument_is_blank_string() {
+    var arguments = new Tool.Arguments(Map.of("boolArg", "   "), null);
+
+    assertThat(arguments.getOptionalBoolean("boolArg")).isNull();
+  }
+
+  @Test
+  void should_return_null_when_optional_string_list_argument_is_empty() {
+    var arguments = new Tool.Arguments(Map.of("listArg", List.of()), null);
+
+    assertThat(arguments.getOptionalStringList("listArg")).isNull();
+  }
+
+  @Test
+  void should_return_null_when_optional_string_list_argument_contains_only_blank_values() {
+    var arguments = new Tool.Arguments(Map.of("listArg", List.of("", " ")), null);
+
+    assertThat(arguments.getOptionalStringList("listArg")).isNull();
+  }
+
+  @Test
+  void should_filter_blank_values_from_optional_string_list_argument() {
+    var arguments = new Tool.Arguments(Map.of("listArg", List.of("", "item1", " ")), null);
+
+    assertThat(arguments.getOptionalStringList("listArg")).containsExactly("item1");
+  }
+
+  @Test
+  void should_filter_null_elements_from_optional_string_list_argument() {
+    var listWithNull = new java.util.ArrayList<String>();
+    listWithNull.add(null);
+    listWithNull.add("item1");
+    var arguments = new Tool.Arguments(Map.of("listArg", listWithNull), null);
+
+    assertThat(arguments.getOptionalStringList("listArg")).containsExactly("item1");
+  }
+
+  @Test
+  void should_return_null_when_optional_enum_argument_is_blank() {
+    var arguments = new Tool.Arguments(Map.of("enumArg", ""), null);
+    var validValues = new String[] {"OPEN", "CLOSED"};
+
+    assertThat(arguments.getOptionalEnumValue("enumArg", validValues)).isNull();
+  }
+
+  @Test
+  void should_throw_exception_when_required_enum_argument_is_blank() {
+    var arguments = new Tool.Arguments(Map.of("enumArg", " "), null);
+    var validValues = new String[] {"OPEN", "CLOSED"};
+
+    assertThatThrownBy(() -> arguments.getEnumOrThrow("enumArg", validValues))
+      .isInstanceOf(MissingRequiredArgumentException.class)
+      .hasMessage("Missing required argument: enumArg");
+  }
+
+  @Test
   void should_return_value_when_int_or_default_argument_is_present() {
     var arguments = new Tool.Arguments(Map.of("intArg", 42), null);
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
@@ -159,15 +159,15 @@ class AnalyzeCodeSnippetToolTests {
   class Connected {
 
     @SonarQubeMcpServerTest
-    void it_should_find_no_issues_in_empty_content(SonarQubeMcpServerTestHarness harness) {
-      mockServerRules(harness, null, List.of("php:S1135"));
+    void it_should_return_an_error_if_fileContent_is_blank(SonarQubeMcpServerTestHarness harness) {
       var mcpClient = harness.withPlugins().newClient();
 
       var result = mcpClient.callTool(
         TOOL_NAME,
         Map.of(AnalyzeCodeSnippetTool.FILE_CONTENT_PROPERTY, ""));
 
-      assertResultEquals(result, "{\"issues\":[],\"issueCount\":0}");
+      assertThat(result.isError()).isTrue();
+      assertThat(result.toString()).contains("Missing required argument: fileContent");
     }
 
     @SonarQubeMcpServerTest

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsToolTests.java
@@ -496,6 +496,61 @@ class SearchSecurityHotspotsToolTests {
           }
         }""");
     }
+
+    @SonarQubeMcpServerTest
+    void it_should_ignore_blank_pull_request(SonarQubeMcpServerTestHarness harness) {
+      var hotspotKey = "AXJMFm6ERa2AinNL_0fP";
+      harness.getMockSonarQubeServer().stubFor(get(HotspotsApi.SEARCH_PATH + "?projectKey=my-project")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes("""
+            {
+                "paging": {
+                  "pageIndex": 1,
+                  "pageSize": 100,
+                  "total": 1
+                },
+                "hotspots": [%s],
+                "components": []
+              }
+            """.formatted(generateHotspot(hotspotKey)).getBytes(StandardCharsets.UTF_8)))));
+      var mcpClient = harness.newClient();
+
+      var result = mcpClient.callTool(
+        SearchSecurityHotspotsTool.TOOL_NAME,
+        Map.of(
+          SearchSecurityHotspotsTool.PROJECT_KEY_PROPERTY, "my-project",
+          SearchSecurityHotspotsTool.PULL_REQUEST_PROPERTY, ""));
+
+      assertResultEquals(result, """
+        {
+          "hotspots" : [ {
+            "key" : "AXJMFm6ERa2AinNL_0fP",
+            "component" : "com.example:project:src/main/java/com/example/Service.java",
+            "project" : "com.example:project",
+            "securityCategory" : "sql-injection",
+            "vulnerabilityProbability" : "HIGH",
+            "status" : "TO_REVIEW",
+            "line" : 42,
+            "message" : "Make sure using this hardcoded IP address is safe here.",
+            "assignee" : "john.doe",
+            "author" : "jane.smith",
+            "creationDate" : "2023-05-13T17:55:39+0200",
+            "updateDate" : "2023-05-14T10:20:15+0200",
+            "textRange" : {
+              "startLine" : 42,
+              "endLine" : 42,
+              "startOffset" : 15,
+              "endOffset" : 30
+            },
+            "ruleKey" : "java:S1313"
+          } ],
+          "paging" : {
+            "pageIndex" : 1,
+            "pageSize" : 100,
+            "total" : 1
+          }
+        }""");
+    }
   }
 
   private static String generateHotspot(String hotspotKey) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Tool argument parsing:**
  - Updated `Tool.Arguments` to treat blank strings as absent for optional parameters (`String`, `Integer`, `Boolean`, `Enum`).
  - Added validation to `getStringOrThrow` and `getEnumOrThrow` to treat blank strings as missing required arguments.
- **List handling:**
  - Improved `getOptionalStringList` to filter out blank entries and return `null` if the list results in empty content.
- **Test coverage:**
  - Added comprehensive test cases in `ToolArgumentsTest` to verify the new blank-string behavior for all argument types.
  - Added integration test in `SearchSecurityHotspotsToolTests` to confirm that blank `pullRequest` arguments are correctly ignored.

<sub>This will update automatically on new commits.</sub>