### PR TITLE
MCP-492 analyze_code_snippet should support .tsx/.jsx

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -53,7 +53,7 @@ The user should provide the following environment variables:
 - Python (including IPython notebooks)
 - Ruby
 - Go
-- JavaScript, TypeScript, JSP
+- JavaScript (`js`, `jsx`), TypeScript (`ts`, `tsx`), JSP
 - PHP
 - XML
 - HTML, CSS

--- a/README.md
+++ b/README.md
@@ -903,10 +903,10 @@ SOCKS5 proxies are supported.
   - `filePath` - Project-relative path of the file to analyze (e.g., `src/main/java/MyClass.java`). Used when the workspace is mounted at `/app/mcp-workspace` - _String_
   - `fileContent` - Complete file content as a string. Required when workspace is not mounted - _String_
   - `codeSnippet` - Code snippet to filter issues (must match content in fileContent) - _String_
-  - `language` - Language of the code (e.g., 'java', 'python', 'javascript') - _String_
+  - `language` - Language of the code (e.g., 'java', 'python', 'js', 'ts', 'tsx', 'jsx') - _String_
   - `scope` - Scope of the file: MAIN or TEST (default: MAIN) - _String_
   
-  **Supported Languages:** Java, Kotlin, Python, Ruby, Go, JavaScript, TypeScript, JSP, PHP, XML, HTML, CSS, CloudFormation, Kubernetes, Terraform, Azure Resource Manager, Ansible, Docker, Secrets detection
+  **Supported Languages:** Java, Kotlin, Python, Ruby, Go, JavaScript (`js`, `jsx`), TypeScript (`ts`, `tsx`), JSP, PHP, XML, HTML, CSS, CloudFormation, Kubernetes, Terraform, Azure Resource Manager, Ansible, Docker, Secrets detection
 
 **When integration with SonarQube for IDE is enabled:**
 - **analyze_file_list** - Analyze files in the current working directory using SonarQube for IDE. This tool connects to a running SonarQube for IDE instance to perform code quality analysis on a list of files.

--- a/src/main/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtils.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtils.java
@@ -16,12 +16,15 @@
  */
 package org.sonarsource.sonarqube.mcp.analysis;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
@@ -29,6 +32,14 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 public class LanguageUtils {
 
   public static final Map<String, Set<Language>> SUPPORTED_LANGUAGES_BY_PLUGIN_KEY = new HashMap<>();
+
+  /**
+   * File-suffix keys that map to exactly one supported {@link SonarLanguage}.
+   * Built from {@link SonarLanguage#getDefaultFileSuffixes()} (e.g. {@code tsx} for TS,
+   * {@code ipynb} for IPYTHON); keys shared by several languages are excluded so language
+   * input can be resolved unambiguously in {@link #getSonarLanguageFromInput(String)}.
+   */
+  private static final Map<String, SonarLanguage> UNAMBIGUOUS_SUFFIX_KEY_TO_LANGUAGE;
 
   static {
     SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.put("kotlin", Set.of(Language.KOTLIN));
@@ -45,6 +56,7 @@ public class LanguageUtils {
     SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.put("php", Set.of(Language.PHP));
     SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.put("xml", Set.of(Language.XML));
     SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.put("web", Set.of(Language.HTML, Language.CSS));
+    UNAMBIGUOUS_SUFFIX_KEY_TO_LANGUAGE = buildUnambiguousSuffixKeyIndex();
   }
 
   public static Set<SonarLanguage> getSupportedSonarLanguages() {
@@ -63,10 +75,12 @@ public class LanguageUtils {
   }
 
   public static String[] getValidLanguageNames() {
-    return SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.values().stream()
-      .flatMap(Set::stream)
-      .map(Language::name)
-      .map(String::toLowerCase)
+    return Stream.concat(
+        SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.values().stream()
+          .flatMap(Set::stream)
+          .map(Language::name)
+          .map(name -> name.toLowerCase(Locale.ROOT)),
+        UNAMBIGUOUS_SUFFIX_KEY_TO_LANGUAGE.keySet().stream())
       .distinct()
       .sorted()
       .toArray(String[]::new);
@@ -78,13 +92,87 @@ public class LanguageUtils {
       return null;
     }
 
+    var languageKey = normalizeLanguageKey(languageInput);
+
     for (var sonarLanguage : getSupportedSonarLanguages()) {
       if (sonarLanguage.name().equalsIgnoreCase(languageInput)) {
         return sonarLanguage;
       }
     }
 
+    return UNAMBIGUOUS_SUFFIX_KEY_TO_LANGUAGE.get(languageKey);
+  }
+
+  private static Map<String, SonarLanguage> buildUnambiguousSuffixKeyIndex() {
+    var keyCounts = new HashMap<String, Integer>();
+    for (var sonarLanguage : getSupportedSonarLanguages()) {
+      fileSuffixLanguageKeys(sonarLanguage).forEach(key -> keyCounts.merge(key, 1, Integer::sum));
+    }
+
+    var index = new HashMap<String, SonarLanguage>();
+    for (var sonarLanguage : getSupportedSonarLanguages()) {
+      fileSuffixLanguageKeys(sonarLanguage)
+        .filter(key -> keyCounts.get(key) == 1)
+        .forEach(key -> index.put(key, sonarLanguage));
+    }
+    return Map.copyOf(index);
+  }
+
+  /**
+   * Resolves the file extension for snippet analysis temp files using {@link SonarLanguage#getDefaultFileSuffixes()}.
+   */
+  public static String resolveAnalysisFileExtension(@Nullable String languageInput, SonarLanguage sonarLanguage) {
+    String extension;
+    if (languageInput != null) {
+      var suffix = findFileSuffixForLanguageKey(sonarLanguage, normalizeLanguageKey(languageInput));
+      extension = suffix != null ? suffix : getPrimaryFileSuffix(sonarLanguage);
+    } else {
+      extension = getPrimaryFileSuffix(sonarLanguage);
+    }
+    return normalizeFileExtension(extension);
+  }
+
+  /**
+   * Language keys derived from {@link SonarLanguage#getDefaultFileSuffixes()} (e.g. {@code ipynb}, {@code tsx}).
+   */
+  private static Stream<String> fileSuffixLanguageKeys(SonarLanguage sonarLanguage) {
+    return Arrays.stream(sonarLanguage.getDefaultFileSuffixes())
+      .map(LanguageUtils::languageKeyFromFileSuffix);
+  }
+
+  @Nullable
+  private static String findFileSuffixForLanguageKey(SonarLanguage sonarLanguage, String languageKey) {
+    for (var suffix : sonarLanguage.getDefaultFileSuffixes()) {
+      if (languageKeyFromFileSuffix(suffix).equals(languageKey)) {
+        return suffix;
+      }
+    }
     return null;
+  }
+
+  private static String getPrimaryFileSuffix(SonarLanguage sonarLanguage) {
+    var suffixes = sonarLanguage.getDefaultFileSuffixes();
+    if (suffixes.length > 0 && !suffixes[0].isBlank()) {
+      return suffixes[0];
+    }
+    return ".txt";
+  }
+
+  private static String languageKeyFromFileSuffix(String fileSuffix) {
+    return fileSuffix.startsWith(".")
+      ? fileSuffix.substring(1).toLowerCase(Locale.ROOT)
+      : fileSuffix.toLowerCase(Locale.ROOT);
+  }
+
+  private static String normalizeFileExtension(String extension) {
+    if (extension.isBlank()) {
+      return ".txt";
+    }
+    return extension.startsWith(".") ? extension : ("." + extension);
+  }
+
+  private static String normalizeLanguageKey(String languageInput) {
+    return languageInput.toLowerCase(Locale.ROOT);
   }
 
   @Nullable

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
@@ -43,6 +43,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.getSonarLanguageFromInput;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.getValidLanguageNames;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.mapSonarLanguageToLanguage;
+import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.resolveAnalysisFileExtension;
 
 public class AnalyzeCodeSnippetTool extends Tool {
 
@@ -100,7 +101,7 @@ public class AnalyzeCodeSnippetTool extends Tool {
     }
     return builder
       .addStringProperty(SNIPPET_PROPERTY, "Code snippet to filter issues - must match content within the analyzed file")
-      .addEnumProperty(LANGUAGE_PROPERTY, VALID_LANGUAGES, "Language of the code (e.g., 'java', 'python', 'js')")
+      .addEnumProperty(LANGUAGE_PROPERTY, VALID_LANGUAGES, "Language of the code (e.g., 'java', 'python', 'ts', 'tsx', 'js', 'jsx')")
       .addEnumProperty(SCOPE_PROPERTY, VALID_SCOPES, "Scope of the file: MAIN or TEST (default: MAIN)")
       .setReadOnlyHint()
       .build();
@@ -179,7 +180,7 @@ public class AnalyzeCodeSnippetTool extends Tool {
     Path tmpFile = null;
     try {
       tmpFile = createTemporaryFileForLanguage(analysisId.toString(), backendService.getWorkDir(), fileContent,
-        sonarLanguage);
+        language, sonarLanguage);
       var clientFileDto = backendService.toClientFileDto(tmpFile, fileContent, mapSonarLanguageToLanguage(sonarLanguage), isTest);
       backendService.addFile(clientFileDto);
       var response = backendService.analyzeFilesAndTrack(analysisId, List.of(tmpFile.toUri())).get(30, TimeUnit.SECONDS);
@@ -221,12 +222,9 @@ public class AnalyzeCodeSnippetTool extends Tool {
     backendService.updateRulesConfiguration(activeRules);
   }
 
-  private static Path createTemporaryFileForLanguage(String analysisId, Path workDir, String fileContent, SonarLanguage language) throws IOException {
-    var defaultFileSuffixes = language.getDefaultFileSuffixes();
-    var extension = defaultFileSuffixes.length > 0 ? defaultFileSuffixes[0] : "";
-    if (extension.isBlank()) {
-      extension = ".txt";
-    }
+  private static Path createTemporaryFileForLanguage(String analysisId, Path workDir, String fileContent,
+    @Nullable String languageInput, SonarLanguage language) throws IOException {
+    var extension = resolveAnalysisFileExtension(languageInput, language);
     var tempFile = workDir.resolve("analysis-" + analysisId + extension);
     Files.writeString(tempFile, fileContent);
     return tempFile;

--- a/src/test/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtilsTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/analysis/LanguageUtilsTests.java
@@ -16,7 +16,12 @@
  */
 package org.sonarsource.sonarqube.mcp.analysis;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 
@@ -40,9 +45,7 @@ class LanguageUtilsTests {
 
   @Test
   void should_return_null_for_null_string_input() {
-    var result = LanguageUtils.getSonarLanguageFromInput(null);
-
-    assertThat(result).isNull();
+    assertThat(LanguageUtils.getSonarLanguageFromInput(null)).isNull();
   }
 
   @Test
@@ -50,6 +53,84 @@ class LanguageUtilsTests {
     var result = LanguageUtils.mapSonarLanguageToLanguage(SonarLanguage.JAVA);
 
     assertThat(result).isEqualTo(Language.JAVA);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "tsx, TS",
+    "TSX, TS",
+    "jsx, JS",
+    "JSX, JS"
+  })
+  void should_resolve_jsx_language_aliases(String input, SonarLanguage expected) {
+    assertThat(LanguageUtils.getSonarLanguageFromInput(input)).isEqualTo(expected);
+  }
+
+  @Test
+  void should_include_only_unambiguous_suffix_keys_in_valid_language_names() {
+    var names = Arrays.asList(LanguageUtils.getValidLanguageNames());
+    var keyCounts = new HashMap<String, Integer>();
+
+    for (var sonarLanguage : LanguageUtils.getSupportedSonarLanguages()) {
+      for (var suffix : sonarLanguage.getDefaultFileSuffixes()) {
+        var key = suffix.startsWith(".") ? suffix.substring(1).toLowerCase(Locale.ROOT) : suffix.toLowerCase(Locale.ROOT);
+        keyCounts.merge(key, 1, Integer::sum);
+        if (keyCounts.get(key) == 1) {
+          assertThat(names).as("missing unambiguous suffix key %s for %s", key, sonarLanguage).contains(key);
+        } else {
+          assertThat(names).as("ambiguous suffix key %s must not be exposed", key).doesNotContain(key);
+        }
+      }
+    }
+  }
+
+  @Test
+  void should_resolve_unambiguous_suffix_keys_only() {
+    var keyCounts = new HashMap<String, Integer>();
+    for (var sonarLanguage : LanguageUtils.getSupportedSonarLanguages()) {
+      for (var suffix : sonarLanguage.getDefaultFileSuffixes()) {
+        var key = suffix.startsWith(".") ? suffix.substring(1) : suffix;
+        keyCounts.merge(key, 1, Integer::sum);
+      }
+    }
+
+    for (var expected : LanguageUtils.getSupportedSonarLanguages()) {
+      for (var suffix : expected.getDefaultFileSuffixes()) {
+        var key = suffix.startsWith(".") ? suffix.substring(1) : suffix;
+        var resolved = LanguageUtils.getSonarLanguageFromInput(key);
+
+        if (keyCounts.get(key) == 1) {
+          assertThat(resolved).as("suffix key %s", key).isEqualTo(expected);
+          var expectedExtension = suffix.startsWith(".") ? suffix : "." + suffix;
+          assertThat(LanguageUtils.resolveAnalysisFileExtension(key, resolved)).isEqualTo(expectedExtension);
+        } else {
+          assertThat(resolved).as("ambiguous suffix key %s", key).isNull();
+        }
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "tsx, TS, .tsx",
+    "jsx, JS, .jsx",
+    "ts, TS, .ts",
+    "js, JS, .js",
+    "ipynb, IPYTHON, .ipynb",
+    "ipython, IPYTHON, .ipynb",
+    "java, JAVA, .java",
+    "jav, JAVA, .jav",
+    "kt, KOTLIN, .kt",
+    "kts, KOTLIN, .kts",
+    "kotlin, KOTLIN, .kt",
+    "php3, PHP, .php3",
+    "jspf, JSP, .jspf"
+  })
+  void should_resolve_language_and_extension(String languageInput, SonarLanguage expectedLanguage, String expectedExtension) {
+    var resolved = LanguageUtils.getSonarLanguageFromInput(languageInput);
+
+    assertThat(resolved).isEqualTo(expectedLanguage);
+    assertThat(LanguageUtils.resolveAnalysisFileExtension(languageInput, resolved)).isEqualTo(expectedExtension);
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
@@ -479,6 +479,34 @@ class AnalyzeCodeSnippetToolTests {
     }
 
     @SonarQubeMcpServerTest
+    void it_should_accept_tsx_as_a_valid_language(SonarQubeMcpServerTestHarness harness) {
+      mockServerRules(harness, null, List.of());
+      var mcpClient = harness.withPlugins().newClient();
+
+      var result = mcpClient.callTool(
+        TOOL_NAME,
+        Map.of(
+          AnalyzeCodeSnippetTool.FILE_CONTENT_PROPERTY, "const C = () => <div>hello</div>;",
+          AnalyzeCodeSnippetTool.LANGUAGE_PROPERTY, "tsx"));
+
+      assertThat(result.isError()).isFalse();
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_accept_jsx_as_a_valid_language(SonarQubeMcpServerTestHarness harness) {
+      mockServerRules(harness, null, List.of());
+      var mcpClient = harness.withPlugins().newClient();
+
+      var result = mcpClient.callTool(
+        TOOL_NAME,
+        Map.of(
+          AnalyzeCodeSnippetTool.FILE_CONTENT_PROPERTY, "const C = () => <div>hello</div>;",
+          AnalyzeCodeSnippetTool.LANGUAGE_PROPERTY, "jsx"));
+
+      assertThat(result.isError()).isFalse();
+    }
+
+    @SonarQubeMcpServerTest
     void it_should_return_error_when_file_path_is_missing(SonarQubeMcpServerTestHarness harness) throws IOException {
       mockServerRules(harness, null, List.of("php:S1135"));
       var workspaceDir = Files.createTempDirectory("sonar-mcp-workspace");


### PR DESCRIPTION
----
## Summary by Gitar

- **Language support:**
  - Updated `AnalyzeCodeSnippetTool` to support `tsx` and `jsx` as valid input languages.
- **Core analysis logic:**
  - Added `resolveAnalysisFileExtension` in `LanguageUtils` to correctly map file extensions based on language input.
  - Updated `getValidLanguageNames` to include all supported `SonarLanguage` file suffix keys.
- **Documentation:**
  - Updated `README.md` and `GEMINI.md` to reflect new language key support for JavaScript and TypeScript.

<sub>This will update automatically on new commits.</sub>