### PR TITLE
MCP-501 Decouple CORS policy from 0.0.0.0 bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ Unencrypted HTTP transport. Use HTTPS instead for multi-user deployments.
 | `SONARQUBE_TRANSPORT`| Set to `http` to enable HTTP transport                           | Not set (stdio) |
 | `SONARQUBE_HTTP_PORT`| Port number (1024-65535)                                         | `8080`          |
 | `SONARQUBE_HTTP_HOST`| Host to bind (defaults to localhost for security)                | `127.0.0.1`     |
+| `SONARQUBE_HTTP_ALLOWED_ORIGINS` | Comma-separated browser origins allowed for CORS (e.g. `https://my-app.example.com`) | Not set |
 | `SONARQUBE_MCP_IN_CONTAINER` | Set to `true` when running inside a container. The official Docker image sets this automatically; set it yourself when using other OCI runtimes (Podman, Kubernetes, Nomad, etc.). | `false` |
 
 **Note:** In HTTP(S) mode, the server is stateless — each client request must include an `Authorization: Bearer <token>` header carrying the user's own SonarQube token. For SonarQube Cloud, the organization is resolved as follows:
@@ -694,12 +695,13 @@ Secure multi-user transport with TLS encryption. Requires SSL certificates.
 
 > ✅ **Recommended for Production:** Use HTTPS when deploying the MCP server for multiple users. The server binds to `127.0.0.1` (localhost) by default for security.
 
-| Environment variable | Description                                                      | Default         |
-|----------------------|------------------------------------------------------------------|-----------------|
-| `SONARQUBE_TRANSPORT`| Set to `https` to enable HTTPS transport                         | Not set (stdio) |
-| `SONARQUBE_HTTP_PORT`| Port number (typically 8443 for HTTPS)                          | `8080`          |
-| `SONARQUBE_HTTP_HOST`| Host to bind (defaults to localhost for security)               | `127.0.0.1`     |
-| `SONARQUBE_MCP_IN_CONTAINER` | Set to `true` when running inside a container. The official Docker image sets this automatically; set it yourself when using other OCI runtimes (Podman, Kubernetes, Nomad, etc.). | `false` |
+| Environment variable             | Description                                                                                                                                                                        | Default         |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `SONARQUBE_TRANSPORT`            | Set to `https` to enable HTTPS transport                                                                                                                                           | Not set (stdio) |
+| `SONARQUBE_HTTP_PORT`            | Port number (typically 8443 for HTTPS)                                                                                                                                             | `8080`          |
+| `SONARQUBE_HTTP_HOST`            | Host to bind (defaults to localhost for security)                                                                                                                                  | `127.0.0.1`     |
+| `SONARQUBE_HTTP_ALLOWED_ORIGINS` | Comma-separated browser origins allowed for CORS (e.g. `https://my-app.example.com`)                                                                                               | Not set         |
+| `SONARQUBE_MCP_IN_CONTAINER`     | Set to `true` when running inside a container. The official Docker image sets this automatically; set it yourself when using other OCI runtimes (Podman, Kubernetes, Nomad, etc.). | `false`         |
 
 **SSL Certificate Configuration (Optional):**
 
@@ -711,7 +713,7 @@ Secure multi-user transport with TLS encryption. Requires SSL certificates.
 
 **Example - Docker with SonarQube Cloud:**
 
-> **Note:** When running in a container, set `SONARQUBE_HTTP_HOST=0.0.0.0` so the container listens on all interfaces and the runtime's port mapping works, and set `SONARQUBE_MCP_IN_CONTAINER=true` to tell the server it is inside a container. The official Docker image sets the latter automatically; set it yourself when using other OCI runtimes (Podman, Kubernetes, Nomad, etc.). The host-side port flag controls who can reach the server from outside the container.
+> **Note:** When running in a container, set `SONARQUBE_HTTP_HOST=0.0.0.0` so the container listens on all interfaces and the runtime's port mapping works, and set `SONARQUBE_MCP_IN_CONTAINER=true` to tell the server it is inside a container. The official Docker image sets the latter automatically; set it yourself when using other OCI runtimes (Podman, Kubernetes, Nomad, etc.). The host-side port flag controls who can reach the server from outside the container. `SONARQUBE_HTTP_HOST=0.0.0.0` only controls where the server listens inside the container — browser CORS still allows localhost origins by default.
 
 For a server running **locally on your machine** (accessible only from localhost):
 ```bash

--- a/docs/http-authentication-architecture.md
+++ b/docs/http-authentication-architecture.md
@@ -268,10 +268,11 @@ Per-request filtering is applied at the **`tools/list` response**: `PerRequestTo
 **Mitigation**: `McpSecurityFilter` validates the `Origin` header.
 
 **Allowed Origins**:
-- When bound to `127.0.0.1` (default): Only `http://localhost`, `http://127.0.0.1`, etc.
-- Additional origins can be whitelisted via `SONARQUBE_HTTP_ALLOWED_ORIGINS` (see below)
+- When bound to `127.0.0.1` or `localhost` (default): Only localhost browser origins (`http://localhost`, `http://127.0.0.1`, `http://[::1]`, with any port).
+- When bound to `0.0.0.0` (required for container port mapping): Same CORS policy as localhost bindings — localhost origins only, not all origins.
+- Additional origins can be whitelisted via `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://sonarcloud.io, https://my-app.example.com`).
 
-> ⚠️ **Important**: The server defaults to binding to `127.0.0.1` (localhost) for security. This is the recommended configuration for local development. Use `SONARQUBE_HTTP_ALLOWED_ORIGINS` to extend the origin allowlist when deploying behind a web application rather than loosening the host binding.
+> ⚠️ **Important**: The server defaults to binding to `127.0.0.1` (localhost) for security. This is the recommended configuration for local development. `SONARQUBE_HTTP_HOST=0.0.0.0` is for container listen address only and does not loosen CORS. Use `SONARQUBE_HTTP_ALLOWED_ORIGINS` to extend the origin allowlist when deploying behind a web application.
 
 ### Token Security
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
@@ -49,7 +49,6 @@ public class McpSecurityFilter implements Filter {
   );
 
   private final String hostBinding;
-  private final boolean allowAllOrigins;
   private final Set<String> extraAllowedOrigins;
   private final String serverVersion;
 
@@ -59,9 +58,6 @@ public class McpSecurityFilter implements Filter {
 
   public McpSecurityFilter(String hostBinding, List<String> extraAllowedOrigins, String serverVersion) {
     this.hostBinding = hostBinding;
-    // Only allow all origins if explicitly bound to all interfaces (0.0.0.0)
-    // Otherwise, restrict to localhost origins
-    this.allowAllOrigins = "0.0.0.0".equals(hostBinding);
     this.extraAllowedOrigins = Set.copyOf(extraAllowedOrigins);
     this.serverVersion = serverVersion;
 
@@ -105,7 +101,7 @@ public class McpSecurityFilter implements Filter {
 
     if (origin != null && isOriginAllowed(origin)) {
       httpResponse.setHeader("Access-Control-Allow-Origin", origin);
-    } else if (allowAllOrigins || isOptionsRequest) {
+    } else if (isOptionsRequest) {
       httpResponse.setHeader("Access-Control-Allow-Origin", "*");
     }
 
@@ -143,16 +139,12 @@ public class McpSecurityFilter implements Filter {
    * Check if the given origin is allowed based on the server's host binding and the configured extra allowed origins.
    */
   private boolean isOriginAllowed(String origin) {
-    if (allowAllOrigins) {
-      return true;
-    }
-
     if (extraAllowedOrigins.contains(origin)) {
       return true;
     }
 
-    // For localhost bindings, only allow localhost origins
-    if ("127.0.0.1".equals(hostBinding) || "localhost".equals(hostBinding)) {
+    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive.
+    if ("127.0.0.1".equals(hostBinding) || "localhost".equals(hostBinding) || "0.0.0.0".equals(hostBinding)) {
       return isLocalhostOrigin(origin);
     }
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
@@ -173,7 +173,8 @@ class McpSecurityFilterTest {
       Arguments.of("127.0.0.1", "http://[::1]:8080", "POST"),   // IPv6 localhost
       Arguments.of("127.0.0.1", "https://127.0.0.1:3000", "POST"),
       Arguments.of("127.0.0.1", "https://[::1]:8080", "POST"),  // IPv6 localhost over HTTPS
-      Arguments.of("0.0.0.0", "https://external-site.com", "POST")
+      Arguments.of("0.0.0.0", "http://localhost:3000", "POST"),
+      Arguments.of("0.0.0.0", "http://127.0.0.1:8080", "POST")
     );
   }
 
@@ -191,14 +192,26 @@ class McpSecurityFilterTest {
   }
 
   @Test
-  void should_use_wildcard_when_bound_to_all_interfaces_without_origin() throws Exception {
+  void should_reject_external_origin_when_bound_to_all_interfaces() throws Exception {
+    var filter = new McpSecurityFilter("0.0.0.0", "1.0.0");
+    when(request.getHeader("Origin")).thenReturn("https://external-site.com");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain, never()).doFilter(any(), any());
+  }
+
+  @Test
+  void should_not_set_origin_header_when_no_origin_and_all_interfaces_binding() throws Exception {
     var filter = new McpSecurityFilter("0.0.0.0", "1.0.0");
     when(request.getHeader("Origin")).thenReturn(null);
     when(request.getMethod()).thenReturn("POST");
 
     filter.doFilter(request, response, filterChain);
 
-    verify(response).setHeader("Access-Control-Allow-Origin", "*");
+    verify(response, never()).setHeader(eq("Access-Control-Allow-Origin"), any());
     verify(filterChain).doFilter(request, response);
   }
 
@@ -268,7 +281,9 @@ class McpSecurityFilterTest {
       Arguments.of("localhost", "http://localhost:3000", "POST", true, "localhost binding accepts localhost origins"),
       Arguments.of("192.168.1.100", "http://localhost:3000", "POST", false, "custom host binding rejects all origins"),
       Arguments.of("127.0.0.1", "https://malicious.com", "GET", false, "GET with disallowed origin should be rejected"),
-      Arguments.of("127.0.0.1", "http://localhost:3000", "POST", true, "POST with allowed origin should be accepted")
+      Arguments.of("127.0.0.1", "http://localhost:3000", "POST", true, "POST with allowed origin should be accepted"),
+      Arguments.of("0.0.0.0", "https://external-site.com", "POST", false, "0.0.0.0 binding rejects external origins"),
+      Arguments.of("0.0.0.0", "http://localhost:3000", "POST", true, "0.0.0.0 binding accepts localhost origins")
     );
   }
 
@@ -276,6 +291,18 @@ class McpSecurityFilterTest {
   void should_accept_multiple_extra_allowed_origins() throws Exception {
     var filter = new McpSecurityFilter("127.0.0.1", List.of("https://sonarcloud.io", "https://sonarqube.us"), "1.0.0");
     when(request.getHeader("Origin")).thenReturn("https://sonarqube.us");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void should_accept_extra_allowed_origin_when_bound_to_all_interfaces() throws Exception {
+    var filter = new McpSecurityFilter("0.0.0.0", List.of("https://sonarcloud.io"), "1.0.0");
+    when(request.getHeader("Origin")).thenReturn("https://sonarcloud.io");
     when(request.getMethod()).thenReturn("POST");
 
     filter.doFilter(request, response, filterChain);


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored CORS security:**
  - Removed automatic wildcard `Access-Control-Allow-Origin: *` when bound to `0.0.0.0` in `McpSecurityFilter.java`.
  - Updated `isOriginAllowed` to maintain strict origin checking even when listening on all interfaces.
- **Documentation updates:**
  - Clarified in `README.md` and `http-authentication-architecture.md` that binding to `0.0.0.0` is for container port mapping and does not affect CORS policy.
  - Added `SONARQUBE_HTTP_ALLOWED_ORIGINS` to environment variable tables.
- **Test suite expansion:**
  - Added regression tests in `McpSecurityFilterTest.java` to verify `0.0.0.0` binding correctly rejects external origins and respects the allowed origin list.

<sub>This will update automatically on new commits.</sub>