### PR TITLE
MCP-503 Redirect certificate installation logs to stderr in Docker

### DIFF
--- a/scripts/install-certificates.sh
+++ b/scripts/install-certificates.sh
@@ -5,10 +5,10 @@
 CERT_DIR="/usr/local/share/ca-certificates/"
 
 if [ "$(ls -A "$CERT_DIR")" ]; then
-    echo "Installing custom certificates from $CERT_DIR..."
+    echo "Installing custom certificates from $CERT_DIR..." >&2
 
     # Run as root via sudo
-    sudo /usr/sbin/update-ca-certificates
+    sudo /usr/sbin/update-ca-certificates >&2
 
-    echo "Custom certificates installed successfully"
+    echo "Custom certificates installed successfully" >&2
 fi


### PR DESCRIPTION
----
## Summary by Gitar

- **Logging updates:**
  - Redirected installation progress and success messages in `install-certificates.sh` to `stderr`.
  - Redirected `update-ca-certificates` output to `stderr` to prevent log interference in Docker stdio mode.

<sub>This will update automatically on new commits.</sub>