### PR TITLE
MCP-512 Update bundled CAG to 0.13.0.1985

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,14 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.8.0.355
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.13.0.1985
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \
         arm64) ARCH="arm64" ;; \
         *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
     esac && \
-    wget -qO- "https://binaries.sonarsource.com/Distribution/sonar-context-augmentation-alpine-${ARCH}/sonar-context-augmentation-alpine-${ARCH}-${SONAR_CONTEXT_AUGMENTATION_VERSION}.tar.gz" \
+    wget -qO- "https://binaries.sonarsource.com/Distribution/sonar-context-augmentation-linux-${ARCH}/sonar-context-augmentation-linux-${ARCH}-${SONAR_CONTEXT_AUGMENTATION_VERSION}.tar.gz" \
     | tar -xz -C /tmp && \
     install -m 755 /tmp/sonar-context-augmentation /usr/local/bin/sonar-context-augmentation && \
     rm -f /tmp/sonar-context-augmentation

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.20-SNAPSHOT
-sonarContextAugmentationVersion=0.8.0.355
+sonarContextAugmentationVersion=0.13.0.1985
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true

--- a/its/build.gradle.kts
+++ b/its/build.gradle.kts
@@ -103,8 +103,8 @@ val downloadCagBinary = tasks.register("downloadCagBinary") {
         tarGz.parentFile.mkdirs()
 
         val url = "https://binaries.sonarsource.com/Distribution/" +
-            "sonar-context-augmentation-alpine-$cagArch/" +
-            "sonar-context-augmentation-alpine-$cagArch-$cagVersion.tar.gz"
+            "sonar-context-augmentation-linux-$cagArch/" +
+            "sonar-context-augmentation-linux-$cagArch-$cagVersion.tar.gz"
         logger.lifecycle("Downloading CAG binary from: $url")
 
         URI(url).toURL().openStream().use { input ->


### PR DESCRIPTION
Most notably, this includes the new language backend (semsitter), and the compass tool. The full release notes can be found at https://sonarsource.atlassian.net/projects/CAG/versions/35232/tab/release-report-all-issues.

----
## Summary by Gitar

- **Dependency update:**
  - Bumped `sonarContextAugmentationVersion` to `0.13.0.1985` in `gradle.properties`.
- **Infrastructure configuration:**
  - Updated `Dockerfile` and `its/build.gradle.kts` to pull the CAG binary from the `linux` distribution directory instead of `alpine`.

<sub>This will update automatically on new commits.</sub>