### PR TITLE
MCP-502 Configure Renovate post-upgrade task to regenerate lock files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,24 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:ide-xp-team"
+  ],
+  "packageRules": [
+    {
+      "description": "Regenerate Gradle lockfiles after dependency updates",
+      "matchManagers": [
+        "gradle",
+        "gradle-wrapper"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "./gradlew --write-locks dependencies :its:dependencies"
+        ],
+        "fileFilters": [
+          "**/gradle.lockfile",
+          "**/settings-gradle.lockfile"
+        ],
+        "executionMode": "branch"
+      }
+    }
   ]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate configuration:**
  - Added `postUpgradeTasks` to `.github/renovate.json` to automatically regenerate Gradle lockfiles after dependency updates.
  - Configured `fileFilters` to include `gradle.lockfile` and `settings-gradle.lockfile` for `gradle` and `gradle-wrapper` managers.

<sub>This will update automatically on new commits.</sub>