### PR TITLE
MCP-528 Pull Gradle plugins from Artifactory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,27 +65,25 @@ jobs:
           version: 2026.6.1
 
       - name: Vault (SonarCloud IT token)
-        id: secrets-sc
+        id: vault_it_token
         uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
         with:
           secrets: |
             development/team/sonarlint/kv/data/sonarcloud-it token | SONARCLOUD_IT_TOKEN;
-            development/kv/data/repox url | ARTIFACTORY_URL;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username | ARTIFACTORY_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+
+      - uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
+        with:
+          artifactory-reader-role: private-reader
 
       - name: Download plugin from Artifactory
         env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets-sc.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets-sc.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets-sc.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           PROJECT_VERSION: ${{ needs.build.outputs.PROJECT_VERSION }}
         run: |
           set -euo pipefail
           echo "Using project version: ${PROJECT_VERSION}"
           DOWNLOAD_URL="${ARTIFACTORY_URL}/sonarsource-public-qa/org/sonarsource/sonarqube/mcp/server/sonarqube-mcp-server/${PROJECT_VERSION}/sonarqube-mcp-server-${PROJECT_VERSION}.jar"
           
-          curl -fsSL -u "${ARTIFACTORY_PRIVATE_USERNAME}:${ARTIFACTORY_PRIVATE_PASSWORD}" \
+          curl -fsSL -u "${ARTIFACTORY_ACCESS_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}" \
             -o sonarqube-mcp-server.jar \
             "${DOWNLOAD_URL}"
           
@@ -94,10 +92,7 @@ jobs:
 
       - name: Run Integration Tests
         env:
-          SONARCLOUD_IT_TOKEN: ${{ steps.secrets-sc.outputs.vault && fromJSON(steps.secrets-sc.outputs.vault).SONARCLOUD_IT_TOKEN || '' }}
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets-sc.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_USER: ${{ fromJSON(steps.secrets-sc.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets-sc.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+          SONARCLOUD_IT_TOKEN: ${{ steps.vault_it_token.outputs.vault && fromJSON(steps.vault_it_token.outputs.vault).SONARCLOUD_IT_TOKEN || '' }}
           DOWNLOADED_JAR_PATH: ${{ github.workspace }}/downloaded-plugin/sonarqube-mcp-server.jar
         run: |
           ./gradlew :its:integrationTest --tests "*${{ matrix.test_class }}" --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,11 +14,11 @@ group = "org.sonarsource.sonarqube.mcp.server"
 val pluginName = "sonarqube-mcp-server"
 val mainClassName = "org.sonarsource.sonarqube.mcp.SonarQubeMcpServer"
 
-// The environment variables ARTIFACTORY_USER and ARTIFACTORY_ACCESS_TOKEN are used on CI env
+// The environment variables ARTIFACTORY_ACCESS_USERNAME and ARTIFACTORY_ACCESS_TOKEN are used on CI env
 // On local box, please add artifactoryUrl, artifactoryUsername and artifactoryPassword to ~/.gradle/gradle.properties
 val artifactoryUrl = System.getenv("ARTIFACTORY_URL")
 	?: (if (project.hasProperty("artifactoryUrl")) project.property("artifactoryUrl").toString() else "")
-val artifactoryUsername = System.getenv("ARTIFACTORY_USER")
+val artifactoryUsername = System.getenv("ARTIFACTORY_ACCESS_USERNAME")
 	?: (if (project.hasProperty("artifactoryUsername")) project.property("artifactoryUsername").toString() else "")
 val artifactoryPassword = System.getenv("ARTIFACTORY_ACCESS_TOKEN")
 	?: (if (project.hasProperty("artifactoryPassword")) project.property("artifactoryPassword").toString() else "")

--- a/its/build.gradle.kts
+++ b/its/build.gradle.kts
@@ -23,7 +23,7 @@ java {
 
 val artifactoryUrl = System.getenv("ARTIFACTORY_URL").orEmpty()
     .ifEmpty { project.findProperty("artifactoryUrl")?.toString().orEmpty() }
-val artifactoryUsername = System.getenv("ARTIFACTORY_USER").orEmpty()
+val artifactoryUsername = System.getenv("ARTIFACTORY_ACCESS_USERNAME").orEmpty()
     .ifEmpty { project.findProperty("artifactoryUsername")?.toString().orEmpty() }
 val artifactoryPassword = System.getenv("ARTIFACTORY_ACCESS_TOKEN").orEmpty()
     .ifEmpty { project.findProperty("artifactoryPassword")?.toString().orEmpty() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,20 @@
+pluginManagement {
+    // This block is compiled earlier than the rest of the script, so keep it self-contained.
+    val artifactoryUrl = System.getenv("ARTIFACTORY_URL") ?: providers.gradleProperty("artifactoryUrl").orNull
+    val artifactoryUsername = System.getenv("ARTIFACTORY_ACCESS_USERNAME") ?: providers.gradleProperty("artifactoryUsername").orNull
+    val artifactoryPassword = System.getenv("ARTIFACTORY_ACCESS_TOKEN") ?: providers.gradleProperty("artifactoryPassword").orNull
+    repositories {
+        maven {
+            if (artifactoryUrl != null && artifactoryUsername != null && artifactoryPassword != null) {
+                url = java.net.URI("$artifactoryUrl/plugins.gradle.org/")
+                credentials { username = artifactoryUsername; password = artifactoryPassword }
+            } else {
+                url = java.net.URI("https://plugins.gradle.org/m2/")
+            }
+        }
+    }
+}
+
 rootProject.name = "sonarqube-mcp-server"
 
 include("its")


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
  - Added `pluginManagement` block to `settings.gradle.kts` to allow pulling Gradle plugins from Artifactory using environment credentials.
- **Environment variable standardization:**
  - Renamed `ARTIFACTORY_USER` to `ARTIFACTORY_ACCESS_USERNAME` across `build.gradle.kts` and `its/build.gradle.kts` for consistency.
- **CI/CD updates:**
  - Updated `.github/workflows/build.yml` to reflect variable name changes and reconfigured the vault integration step to use the updated credentials.

<sub>This will update automatically on new commits.</sub>