### PR TITLE
MCP-530 Relax Origin check for authenticated and bootstrap requests

### DIFF
--- a/docs/http-authentication-architecture.md
+++ b/docs/http-authentication-architecture.md
@@ -267,16 +267,16 @@ Per-request filtering is applied at the **`tools/list` response**: `PerRequestTo
 
 **Mitigation**: `McpSecurityFilter` validates the `Origin` header as a browser-layer backstop on local bindings. Bearer authentication remains the primary control.
 
-**Local binding detection**: loopback addresses via `InetAddress.isLoopbackAddress()` (`127.0.0.1`, `localhost`, `::1`, `127.0.0.2`, …), plus `0.0.0.0` for container deployments.
-
 **Origin enforcement** (returns 403 when triggered):
-- Applies on local bindings for unauthenticated requests to paths other than `/mcp` and `/.well-known/*`.
-- Skipped when the request carries `Authorization: Bearer …` or the legacy `SONARQUBE_TOKEN` header.
-- Skipped on OAuth bootstrap paths without a token (`/mcp`, `/.well-known/*`) — those receive 401 from the auth layer instead.
-- Not applied on non-loopback host bindings.
+- Applies only on local bindings (`127.0.0.1`, `localhost`, `0.0.0.0`).
+- Skipped when the request carries `Authorization: Bearer …` or the legacy `SONARQUBE_TOKEN` header (native MCP clients).
+- Skipped on OAuth bootstrap paths without a token: `POST /mcp` (401 discovery) and `GET /.well-known/*` (Protected Resource Metadata).
+- Not applied on remote host bindings (e.g. SonarQube Cloud hosted); use `SONARQUBE_HTTP_ALLOWED_ORIGINS` for browser CORS only.
 
-**CORS allowlist** (sets `Access-Control-Allow-Origin`):
-- Loopback browser origins plus entries in `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://my-app.example.com`).
+**Allowed Origins** (for CORS response headers and local enforcement):
+- When bound to `127.0.0.1` or `localhost` (default): localhost browser origins (`http://localhost`, `http://127.0.0.1`, `http://[::1]`, with any port).
+- When bound to `0.0.0.0` (required for container port mapping): same CORS policy as localhost bindings.
+- Additional origins can be whitelisted via `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://sonarcloud.io, https://my-app.example.com`).
 
 > ⚠️ **Important**: The server defaults to binding to `127.0.0.1` (localhost) for security. This is the recommended configuration for local development. `SONARQUBE_HTTP_HOST=0.0.0.0` is for container listen address only. Use `SONARQUBE_HTTP_ALLOWED_ORIGINS` to extend the origin allowlist when deploying behind a web application.
 

--- a/docs/http-authentication-architecture.md
+++ b/docs/http-authentication-architecture.md
@@ -265,14 +265,20 @@ Per-request filtering is applied at the **`tools/list` response**: `PerRequestTo
 
 **Threat**: Attacker could use DNS rebinding to access a local MCP server from a remote website.
 
-**Mitigation**: `McpSecurityFilter` validates the `Origin` header.
+**Mitigation**: `McpSecurityFilter` validates the `Origin` header as a browser-layer backstop on local bindings. Bearer authentication remains the primary control.
 
-**Allowed Origins**:
-- When bound to `127.0.0.1` or `localhost` (default): Only localhost browser origins (`http://localhost`, `http://127.0.0.1`, `http://[::1]`, with any port).
-- When bound to `0.0.0.0` (required for container port mapping): Same CORS policy as localhost bindings — localhost origins only, not all origins.
-- Additional origins can be added to an allowlist via `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://sonarcloud.io, https://my-app.example.com`).
+**Origin enforcement** (returns 403 when triggered):
+- Applies only on local bindings (`127.0.0.1`, `localhost`, `0.0.0.0`).
+- Skipped when the request carries `Authorization: Bearer …` or the legacy `SONARQUBE_TOKEN` header (native MCP clients).
+- Skipped on OAuth bootstrap paths without a token: `POST /mcp` (401 discovery) and `GET /.well-known/*` (Protected Resource Metadata).
+- Not applied on remote host bindings (e.g. SonarQube Cloud hosted); use `SONARQUBE_HTTP_ALLOWED_ORIGINS` for browser CORS only.
 
-> ⚠️ **Important**: The server defaults to binding to `127.0.0.1` (localhost) for security. This is the recommended configuration for local development. `SONARQUBE_HTTP_HOST=0.0.0.0` is for container listen address only and does not loosen CORS. Use `SONARQUBE_HTTP_ALLOWED_ORIGINS` to extend the origin allowlist when deploying behind a web application.
+**Allowed Origins** (for CORS response headers and local enforcement):
+- When bound to `127.0.0.1` or `localhost` (default): localhost browser origins (`http://localhost`, `http://127.0.0.1`, `http://[::1]`, with any port).
+- When bound to `0.0.0.0` (required for container port mapping): same CORS policy as localhost bindings.
+- Additional origins can be whitelisted via `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://sonarcloud.io, https://my-app.example.com`).
+
+> ⚠️ **Important**: The server defaults to binding to `127.0.0.1` (localhost) for security. This is the recommended configuration for local development. `SONARQUBE_HTTP_HOST=0.0.0.0` is for container listen address only. Use `SONARQUBE_HTTP_ALLOWED_ORIGINS` to extend the origin allowlist when deploying behind a web application.
 
 ### Token Security
 

--- a/docs/http-authentication-architecture.md
+++ b/docs/http-authentication-architecture.md
@@ -267,16 +267,16 @@ Per-request filtering is applied at the **`tools/list` response**: `PerRequestTo
 
 **Mitigation**: `McpSecurityFilter` validates the `Origin` header as a browser-layer backstop on local bindings. Bearer authentication remains the primary control.
 
-**Origin enforcement** (returns 403 when triggered):
-- Applies only on local bindings (`127.0.0.1`, `localhost`, `0.0.0.0`).
-- Skipped when the request carries `Authorization: Bearer …` or the legacy `SONARQUBE_TOKEN` header (native MCP clients).
-- Skipped on OAuth bootstrap paths without a token: `POST /mcp` (401 discovery) and `GET /.well-known/*` (Protected Resource Metadata).
-- Not applied on remote host bindings (e.g. SonarQube Cloud hosted); use `SONARQUBE_HTTP_ALLOWED_ORIGINS` for browser CORS only.
+**Local binding detection**: loopback addresses via `InetAddress.isLoopbackAddress()` (`127.0.0.1`, `localhost`, `::1`, `127.0.0.2`, …), plus `0.0.0.0` for container deployments.
 
-**Allowed Origins** (for CORS response headers and local enforcement):
-- When bound to `127.0.0.1` or `localhost` (default): localhost browser origins (`http://localhost`, `http://127.0.0.1`, `http://[::1]`, with any port).
-- When bound to `0.0.0.0` (required for container port mapping): same CORS policy as localhost bindings.
-- Additional origins can be whitelisted via `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://sonarcloud.io, https://my-app.example.com`).
+**Origin enforcement** (returns 403 when triggered):
+- Applies on local bindings for unauthenticated requests to paths other than `/mcp` and `/.well-known/*`.
+- Skipped when the request carries `Authorization: Bearer …` or the legacy `SONARQUBE_TOKEN` header.
+- Skipped on OAuth bootstrap paths without a token (`/mcp`, `/.well-known/*`) — those receive 401 from the auth layer instead.
+- Not applied on non-loopback host bindings.
+
+**CORS allowlist** (sets `Access-Control-Allow-Origin`):
+- Loopback browser origins plus entries in `SONARQUBE_HTTP_ALLOWED_ORIGINS` (comma-separated full origin URLs, e.g. `https://my-app.example.com`).
 
 > ⚠️ **Important**: The server defaults to binding to `127.0.0.1` (localhost) for security. This is the recommended configuration for local development. `SONARQUBE_HTTP_HOST=0.0.0.0` is for container listen address only. Use `SONARQUBE_HTTP_ALLOWED_ORIGINS` to extend the origin allowlist when deploying behind a web application.
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.authentication.AuthenticationFilter;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
 
@@ -98,7 +99,7 @@ public class McpSecurityFilter implements Filter {
     var origin = httpRequest.getHeader("Origin");
     boolean isOptionsRequest = "OPTIONS".equals(httpRequest.getMethod());
 
-    if (origin != null && !origin.isBlank() && shouldEnforceOrigin(httpRequest) && !isOriginAllowed(origin)) {
+    if (!isOriginAllowed(httpRequest, origin)) {
       LOG.warn("Rejected request from disallowed origin: " + origin);
       httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
       httpResponse.setContentType("application/json");
@@ -106,7 +107,7 @@ public class McpSecurityFilter implements Filter {
       return;
     }
 
-    if (origin != null && isOriginAllowed(origin)) {
+    if (origin != null && isOriginInAllowlist(origin)) {
       httpResponse.setHeader("Access-Control-Allow-Origin", origin);
     } else if (isOptionsRequest) {
       httpResponse.setHeader("Access-Control-Allow-Origin", "*");
@@ -143,17 +144,40 @@ public class McpSecurityFilter implements Filter {
   }
 
   /**
-   * Whether to reject a disallowed {@code Origin} header.
-   * Skipped for authenticated requests, OAuth bootstrap paths, and remote deployments.
+   * Whether the request may proceed given its {@code Origin} header.
+   * Absent, blank, authenticated, OAuth-bootstrap, remote-binding, and allowlisted origins are permitted.
    */
-  private boolean shouldEnforceOrigin(HttpServletRequest request) {
+  private boolean isOriginAllowed(HttpServletRequest request, @Nullable String origin) {
+    if (origin == null || origin.isBlank()) {
+      return true;
+    }
     if (!isLocalBinding()) {
-      return false;
+      return true;
     }
     if (hasAuthToken(request)) {
-      return false;
+      return true;
     }
-    return !isOAuthBootstrapRequest(request);
+    if (isOAuthBootstrapRequest(request)) {
+      return true;
+    }
+    return isOriginInAllowlist(origin);
+  }
+
+  /**
+   * Whether the origin may be reflected in CORS response headers.
+   */
+  private boolean isOriginInAllowlist(String origin) {
+    if (extraAllowedOrigins.contains(origin)) {
+      return true;
+    }
+
+    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive on local bindings.
+    if (isLocalBinding()) {
+      return isLocalhostOrigin(origin);
+    }
+
+    // For other specific host bindings, be restrictive
+    return false;
   }
 
   private boolean isLocalBinding() {
@@ -174,23 +198,6 @@ public class McpSecurityFilter implements Filter {
     return MCP_ENDPOINT.equals(path) || path.startsWith(WELL_KNOWN_PREFIX);
   }
 
-  /**
-   * Check if the given origin is allowed based on the server's host binding and the configured extra allowed origins.
-   */
-  private boolean isOriginAllowed(String origin) {
-    if (extraAllowedOrigins.contains(origin)) {
-      return true;
-    }
-
-    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive on local bindings.
-    if (isLocalBinding()) {
-      return isLocalhostOrigin(origin);
-    }
-
-    // For other specific host bindings, be restrictive
-    return false;
-  }
-  
   /**
    * Check if the origin is a valid localhost origin.
    * Parses the URL to extract the host and checks for exact match.

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
@@ -28,11 +28,16 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Set;
+import org.sonarsource.sonarqube.mcp.authentication.AuthenticationFilter;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
 
 /**
  * Security filter for MCP HTTP transport to prevent DNS rebinding attacks
  * and enforce security best practices per MCP specification.
+ * <p>
+ * Origin enforcement is a browser-layer backstop for local deployments. Native MCP clients
+ * authenticate with Bearer tokens and may send non-localhost {@code Origin} headers; OAuth
+ * bootstrap requests intentionally arrive without a token and are allowed through to receive 401.
  */
 public class McpSecurityFilter implements Filter {
 
@@ -40,6 +45,8 @@ public class McpSecurityFilter implements Filter {
 
   static final String HEALTH_ENDPOINT = "/health";
   static final String INFO_ENDPOINT = "/info";
+  static final String MCP_ENDPOINT = "/mcp";
+  private static final String WELL_KNOWN_PREFIX = "/.well-known/";
 
   // Allowed hosts for localhost deployments (exact match only)
   private static final Set<String> ALLOWED_LOCALHOST_HOSTS = Set.of(
@@ -91,7 +98,7 @@ public class McpSecurityFilter implements Filter {
     var origin = httpRequest.getHeader("Origin");
     boolean isOptionsRequest = "OPTIONS".equals(httpRequest.getMethod());
 
-    if (origin != null && !isOriginAllowed(origin)) {
+    if (origin != null && !origin.isBlank() && shouldEnforceOrigin(httpRequest) && !isOriginAllowed(origin)) {
       LOG.warn("Rejected request from disallowed origin: " + origin);
       httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
       httpResponse.setContentType("application/json");
@@ -136,6 +143,38 @@ public class McpSecurityFilter implements Filter {
   }
 
   /**
+   * Whether to reject a disallowed {@code Origin} header.
+   * Skipped for authenticated requests, OAuth bootstrap paths, and remote deployments.
+   */
+  private boolean shouldEnforceOrigin(HttpServletRequest request) {
+    if (!isLocalBinding()) {
+      return false;
+    }
+    if (hasAuthToken(request)) {
+      return false;
+    }
+    return !isOAuthBootstrapRequest(request);
+  }
+
+  private boolean isLocalBinding() {
+    return "127.0.0.1".equals(hostBinding) || "localhost".equals(hostBinding) || "0.0.0.0".equals(hostBinding);
+  }
+
+  private static boolean hasAuthToken(HttpServletRequest request) {
+    var token = AuthenticationFilter.extractToken(request);
+    return token != null && !token.isBlank();
+  }
+
+  private static boolean isOAuthBootstrapRequest(HttpServletRequest request) {
+    // Safe while AuthenticationFilter rejects tokenless /mcp requests (see HttpServerTransportIntegrationTest).
+    var path = request.getRequestURI();
+    if (path == null) {
+      return false;
+    }
+    return MCP_ENDPOINT.equals(path) || path.startsWith(WELL_KNOWN_PREFIX);
+  }
+
+  /**
    * Check if the given origin is allowed based on the server's host binding and the configured extra allowed origins.
    */
   private boolean isOriginAllowed(String origin) {
@@ -143,8 +182,8 @@ public class McpSecurityFilter implements Filter {
       return true;
     }
 
-    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive.
-    if ("127.0.0.1".equals(hostBinding) || "localhost".equals(hostBinding) || "0.0.0.0".equals(hostBinding)) {
+    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive on local bindings.
+    if (isLocalBinding()) {
       return isLocalhostOrigin(origin);
     }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
@@ -25,12 +25,9 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.authentication.AuthenticationFilter;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
 
@@ -39,7 +36,7 @@ import org.sonarsource.sonarqube.mcp.log.McpLogger;
  * and enforce security best practices per MCP specification.
  * <p>
  * Origin enforcement is a browser-layer backstop for local deployments. Native MCP clients
- * authenticate with Bearer tokens and may send non-loopback {@code Origin} headers; OAuth
+ * authenticate with Bearer tokens and may send non-localhost {@code Origin} headers; OAuth
  * bootstrap requests intentionally arrive without a token and are allowed through to receive 401.
  */
 public class McpSecurityFilter implements Filter {
@@ -50,6 +47,13 @@ public class McpSecurityFilter implements Filter {
   static final String INFO_ENDPOINT = "/info";
   static final String MCP_ENDPOINT = "/mcp";
   private static final String WELL_KNOWN_PREFIX = "/.well-known/";
+
+  // Allowed hosts for localhost deployments (exact match only)
+  private static final Set<String> ALLOWED_LOCALHOST_HOSTS = Set.of(
+    "localhost",
+    "127.0.0.1",
+    "[::1]"
+  );
 
   private final String hostBinding;
   private final Set<String> extraAllowedOrigins;
@@ -94,7 +98,7 @@ public class McpSecurityFilter implements Filter {
     var origin = httpRequest.getHeader("Origin");
     boolean isOptionsRequest = "OPTIONS".equals(httpRequest.getMethod());
 
-    if (!isOriginAllowed(httpRequest, origin)) {
+    if (origin != null && !origin.isBlank() && shouldEnforceOrigin(httpRequest) && !isOriginAllowed(origin)) {
       LOG.warn("Rejected request from disallowed origin: " + origin);
       httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
       httpResponse.setContentType("application/json");
@@ -102,7 +106,7 @@ public class McpSecurityFilter implements Filter {
       return;
     }
 
-    if (origin != null && isOriginInAllowlist(origin)) {
+    if (origin != null && isOriginAllowed(origin)) {
       httpResponse.setHeader("Access-Control-Allow-Origin", origin);
     } else if (isOptionsRequest) {
       httpResponse.setHeader("Access-Control-Allow-Origin", "*");
@@ -139,49 +143,21 @@ public class McpSecurityFilter implements Filter {
   }
 
   /**
-   * Whether the request may proceed given its {@code Origin} header.
-   * Absent, blank, authenticated, OAuth-bootstrap, remote-binding, and allowlisted origins are permitted.
+   * Whether to reject a disallowed {@code Origin} header.
+   * Skipped for authenticated requests, OAuth bootstrap paths, and remote deployments.
    */
-  private boolean isOriginAllowed(HttpServletRequest request, @Nullable String origin) {
-    if (origin == null || origin.isBlank()) {
-      return true;
-    }
+  private boolean shouldEnforceOrigin(HttpServletRequest request) {
     if (!isLocalBinding()) {
-      return true;
+      return false;
     }
     if (hasAuthToken(request)) {
-      return true;
+      return false;
     }
-    if (isOAuthBootstrapRequest(request)) {
-      return true;
-    }
-    return isOriginInAllowlist(origin);
-  }
-
-  /**
-   * Whether the origin may be reflected in CORS response headers.
-   */
-  private boolean isOriginInAllowlist(String origin) {
-    if (extraAllowedOrigins.contains(origin)) {
-      return true;
-    }
-    if (isLocalBinding()) {
-      return isLoopbackOrigin(origin);
-    }
-    return false;
+    return !isOAuthBootstrapRequest(request);
   }
 
   private boolean isLocalBinding() {
-    if ("0.0.0.0".equals(hostBinding)) {
-      // Required for container port mapping; origin policy stays restrictive on local bindings.
-      return true;
-    }
-    try {
-      return InetAddress.getByName(hostBinding).isLoopbackAddress();
-    } catch (UnknownHostException e) {
-      LOG.warn("Could not resolve host binding '" + hostBinding + "' for origin policy: " + e.getMessage());
-      return false;
-    }
+    return "127.0.0.1".equals(hostBinding) || "localhost".equals(hostBinding) || "0.0.0.0".equals(hostBinding);
   }
 
   private static boolean hasAuthToken(HttpServletRequest request) {
@@ -198,22 +174,45 @@ public class McpSecurityFilter implements Filter {
     return MCP_ENDPOINT.equals(path) || path.startsWith(WELL_KNOWN_PREFIX);
   }
 
-  private static boolean isLoopbackOrigin(String origin) {
+  /**
+   * Check if the given origin is allowed based on the server's host binding and the configured extra allowed origins.
+   */
+  private boolean isOriginAllowed(String origin) {
+    if (extraAllowedOrigins.contains(origin)) {
+      return true;
+    }
+
+    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive on local bindings.
+    if (isLocalBinding()) {
+      return isLocalhostOrigin(origin);
+    }
+
+    // For other specific host bindings, be restrictive
+    return false;
+  }
+  
+  /**
+   * Check if the origin is a valid localhost origin.
+   * Parses the URL to extract the host and checks for exact match.
+   */
+  private static boolean isLocalhostOrigin(String origin) {
     try {
       var uri = URI.create(origin);
+      var host = uri.getHost();
       var scheme = uri.getScheme();
+      
+      // Must be http or https
       if (!"http".equals(scheme) && !"https".equals(scheme)) {
         return false;
       }
-      var host = uri.getHost();
-      if (host == null) {
-        return false;
-      }
-      return InetAddress.getByName(host).isLoopbackAddress();
-    } catch (UnknownHostException | IllegalArgumentException e) {
-      LOG.warn("Rejected malformed or unknown origin: " + origin);
+      
+      // Host must exactly match allowed localhost hosts
+      return host != null && ALLOWED_LOCALHOST_HOSTS.contains(host);
+    } catch (IllegalArgumentException e) {
+      LOG.warn("Rejected malformed origin: " + origin);
       return false;
     }
   }
 
 }
+

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilter.java
@@ -25,9 +25,12 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.authentication.AuthenticationFilter;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
 
@@ -36,7 +39,7 @@ import org.sonarsource.sonarqube.mcp.log.McpLogger;
  * and enforce security best practices per MCP specification.
  * <p>
  * Origin enforcement is a browser-layer backstop for local deployments. Native MCP clients
- * authenticate with Bearer tokens and may send non-localhost {@code Origin} headers; OAuth
+ * authenticate with Bearer tokens and may send non-loopback {@code Origin} headers; OAuth
  * bootstrap requests intentionally arrive without a token and are allowed through to receive 401.
  */
 public class McpSecurityFilter implements Filter {
@@ -47,13 +50,6 @@ public class McpSecurityFilter implements Filter {
   static final String INFO_ENDPOINT = "/info";
   static final String MCP_ENDPOINT = "/mcp";
   private static final String WELL_KNOWN_PREFIX = "/.well-known/";
-
-  // Allowed hosts for localhost deployments (exact match only)
-  private static final Set<String> ALLOWED_LOCALHOST_HOSTS = Set.of(
-    "localhost",
-    "127.0.0.1",
-    "[::1]"
-  );
 
   private final String hostBinding;
   private final Set<String> extraAllowedOrigins;
@@ -98,7 +94,7 @@ public class McpSecurityFilter implements Filter {
     var origin = httpRequest.getHeader("Origin");
     boolean isOptionsRequest = "OPTIONS".equals(httpRequest.getMethod());
 
-    if (origin != null && !origin.isBlank() && shouldEnforceOrigin(httpRequest) && !isOriginAllowed(origin)) {
+    if (!isOriginAllowed(httpRequest, origin)) {
       LOG.warn("Rejected request from disallowed origin: " + origin);
       httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
       httpResponse.setContentType("application/json");
@@ -106,7 +102,7 @@ public class McpSecurityFilter implements Filter {
       return;
     }
 
-    if (origin != null && isOriginAllowed(origin)) {
+    if (origin != null && isOriginInAllowlist(origin)) {
       httpResponse.setHeader("Access-Control-Allow-Origin", origin);
     } else if (isOptionsRequest) {
       httpResponse.setHeader("Access-Control-Allow-Origin", "*");
@@ -143,21 +139,49 @@ public class McpSecurityFilter implements Filter {
   }
 
   /**
-   * Whether to reject a disallowed {@code Origin} header.
-   * Skipped for authenticated requests, OAuth bootstrap paths, and remote deployments.
+   * Whether the request may proceed given its {@code Origin} header.
+   * Absent, blank, authenticated, OAuth-bootstrap, remote-binding, and allowlisted origins are permitted.
    */
-  private boolean shouldEnforceOrigin(HttpServletRequest request) {
+  private boolean isOriginAllowed(HttpServletRequest request, @Nullable String origin) {
+    if (origin == null || origin.isBlank()) {
+      return true;
+    }
     if (!isLocalBinding()) {
-      return false;
+      return true;
     }
     if (hasAuthToken(request)) {
-      return false;
+      return true;
     }
-    return !isOAuthBootstrapRequest(request);
+    if (isOAuthBootstrapRequest(request)) {
+      return true;
+    }
+    return isOriginInAllowlist(origin);
+  }
+
+  /**
+   * Whether the origin may be reflected in CORS response headers.
+   */
+  private boolean isOriginInAllowlist(String origin) {
+    if (extraAllowedOrigins.contains(origin)) {
+      return true;
+    }
+    if (isLocalBinding()) {
+      return isLoopbackOrigin(origin);
+    }
+    return false;
   }
 
   private boolean isLocalBinding() {
-    return "127.0.0.1".equals(hostBinding) || "localhost".equals(hostBinding) || "0.0.0.0".equals(hostBinding);
+    if ("0.0.0.0".equals(hostBinding)) {
+      // Required for container port mapping; origin policy stays restrictive on local bindings.
+      return true;
+    }
+    try {
+      return InetAddress.getByName(hostBinding).isLoopbackAddress();
+    } catch (UnknownHostException e) {
+      LOG.warn("Could not resolve host binding '" + hostBinding + "' for origin policy: " + e.getMessage());
+      return false;
+    }
   }
 
   private static boolean hasAuthToken(HttpServletRequest request) {
@@ -174,45 +198,22 @@ public class McpSecurityFilter implements Filter {
     return MCP_ENDPOINT.equals(path) || path.startsWith(WELL_KNOWN_PREFIX);
   }
 
-  /**
-   * Check if the given origin is allowed based on the server's host binding and the configured extra allowed origins.
-   */
-  private boolean isOriginAllowed(String origin) {
-    if (extraAllowedOrigins.contains(origin)) {
-      return true;
-    }
-
-    // 0.0.0.0 is required for container port mapping; CORS policy stays restrictive on local bindings.
-    if (isLocalBinding()) {
-      return isLocalhostOrigin(origin);
-    }
-
-    // For other specific host bindings, be restrictive
-    return false;
-  }
-  
-  /**
-   * Check if the origin is a valid localhost origin.
-   * Parses the URL to extract the host and checks for exact match.
-   */
-  private static boolean isLocalhostOrigin(String origin) {
+  private static boolean isLoopbackOrigin(String origin) {
     try {
       var uri = URI.create(origin);
-      var host = uri.getHost();
       var scheme = uri.getScheme();
-      
-      // Must be http or https
       if (!"http".equals(scheme) && !"https".equals(scheme)) {
         return false;
       }
-      
-      // Host must exactly match allowed localhost hosts
-      return host != null && ALLOWED_LOCALHOST_HOSTS.contains(host);
-    } catch (IllegalArgumentException e) {
-      LOG.warn("Rejected malformed origin: " + origin);
+      var host = uri.getHost();
+      if (host == null) {
+        return false;
+      }
+      return InetAddress.getByName(host).isLoopbackAddress();
+    } catch (UnknownHostException | IllegalArgumentException e) {
+      LOG.warn("Rejected malformed or unknown origin: " + origin);
       return false;
     }
   }
 
 }
-

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportIntegrationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportIntegrationTest.java
@@ -164,7 +164,7 @@ class HttpServerTransportIntegrationTest {
         .uri(URI.create(httpServer.getServerUrl()))
         .POST(HttpRequest.BodyPublishers.ofString("{}"))
         .header("Content-Type", "application/json")
-        .header("Origin", "https://evil.com")
+        .header("Origin", "https://cursor.com")
         .build();
 
       var response = client.send(request, HttpResponse.BodyHandlers.ofString());
@@ -172,6 +172,64 @@ class HttpServerTransportIntegrationTest {
       assertThat(response.statusCode()).isEqualTo(401);
       assertThat(response.statusCode()).isNotEqualTo(403);
       assertThat(response.body()).contains("SonarQube token required");
+    }
+  }
+
+  @Test
+  void should_allow_authenticated_mcp_with_external_origin_on_container_binding() throws Exception {
+    var containerPort = findAvailablePort();
+    var containerServer = new HttpServerTransportProvider(containerPort, "0.0.0.0", AuthMode.TOKEN, false, null, false,
+      Paths.get("keystore.p12"), "sonarlint", "PKCS12", null, null, null, List.of(), "1.0.0", true);
+
+    try {
+      containerServer.startServer().join();
+      var serverUrl = "http://127.0.0.1:" + containerPort + "/mcp";
+      await().atMost(5, TimeUnit.SECONDS).until(() -> isServerRunning(serverUrl));
+
+      try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
+        var request = HttpRequest.newBuilder()
+          .uri(URI.create(serverUrl))
+          .POST(HttpRequest.BodyPublishers.ofString("{}"))
+          .header("Content-Type", "application/json")
+          .header("Origin", "https://cursor.com")
+          .header("Authorization", "Bearer my-token")
+          .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isNotEqualTo(403);
+      }
+    } finally {
+      containerServer.stopServer();
+    }
+  }
+
+  @Test
+  void should_reject_unauthenticated_external_origin_on_non_mcp_path() throws Exception {
+    var containerPort = findAvailablePort();
+    var containerServer = new HttpServerTransportProvider(containerPort, "0.0.0.0", AuthMode.TOKEN, false, null, false,
+      Paths.get("keystore.p12"), "sonarlint", "PKCS12", null, null, null, List.of(), "1.0.0", true);
+
+    try {
+      containerServer.startServer().join();
+      var otherPathUrl = "http://127.0.0.1:" + containerPort + "/other";
+      await().atMost(5, TimeUnit.SECONDS).until(() -> isServerRunning("http://127.0.0.1:" + containerPort + "/mcp"));
+
+      try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
+        var request = HttpRequest.newBuilder()
+          .uri(URI.create(otherPathUrl))
+          .POST(HttpRequest.BodyPublishers.ofString("{}"))
+          .header("Content-Type", "application/json")
+          .header("Origin", "https://cursor.com")
+          .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(403);
+        assertThat(response.body()).contains("Origin not allowed");
+      }
+    } finally {
+      containerServer.stopServer();
     }
   }
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportIntegrationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportIntegrationTest.java
@@ -164,7 +164,7 @@ class HttpServerTransportIntegrationTest {
         .uri(URI.create(httpServer.getServerUrl()))
         .POST(HttpRequest.BodyPublishers.ofString("{}"))
         .header("Content-Type", "application/json")
-        .header("Origin", "https://cursor.com")
+        .header("Origin", "https://evil.com")
         .build();
 
       var response = client.send(request, HttpResponse.BodyHandlers.ofString());
@@ -172,64 +172,6 @@ class HttpServerTransportIntegrationTest {
       assertThat(response.statusCode()).isEqualTo(401);
       assertThat(response.statusCode()).isNotEqualTo(403);
       assertThat(response.body()).contains("SonarQube token required");
-    }
-  }
-
-  @Test
-  void should_allow_authenticated_mcp_with_external_origin_on_container_binding() throws Exception {
-    var containerPort = findAvailablePort();
-    var containerServer = new HttpServerTransportProvider(containerPort, "0.0.0.0", AuthMode.TOKEN, false, null, false,
-      Paths.get("keystore.p12"), "sonarlint", "PKCS12", null, null, null, List.of(), "1.0.0", true);
-
-    try {
-      containerServer.startServer().join();
-      var serverUrl = "http://127.0.0.1:" + containerPort + "/mcp";
-      await().atMost(5, TimeUnit.SECONDS).until(() -> isServerRunning(serverUrl));
-
-      try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
-        var request = HttpRequest.newBuilder()
-          .uri(URI.create(serverUrl))
-          .POST(HttpRequest.BodyPublishers.ofString("{}"))
-          .header("Content-Type", "application/json")
-          .header("Origin", "https://cursor.com")
-          .header("Authorization", "Bearer my-token")
-          .build();
-
-        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-        assertThat(response.statusCode()).isNotEqualTo(403);
-      }
-    } finally {
-      containerServer.stopServer();
-    }
-  }
-
-  @Test
-  void should_reject_unauthenticated_external_origin_on_non_mcp_path() throws Exception {
-    var containerPort = findAvailablePort();
-    var containerServer = new HttpServerTransportProvider(containerPort, "0.0.0.0", AuthMode.TOKEN, false, null, false,
-      Paths.get("keystore.p12"), "sonarlint", "PKCS12", null, null, null, List.of(), "1.0.0", true);
-
-    try {
-      containerServer.startServer().join();
-      var otherPathUrl = "http://127.0.0.1:" + containerPort + "/other";
-      await().atMost(5, TimeUnit.SECONDS).until(() -> isServerRunning("http://127.0.0.1:" + containerPort + "/mcp"));
-
-      try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
-        var request = HttpRequest.newBuilder()
-          .uri(URI.create(otherPathUrl))
-          .POST(HttpRequest.BodyPublishers.ofString("{}"))
-          .header("Content-Type", "application/json")
-          .header("Origin", "https://cursor.com")
-          .build();
-
-        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-        assertThat(response.statusCode()).isEqualTo(403);
-        assertThat(response.body()).contains("Origin not allowed");
-      }
-    } finally {
-      containerServer.stopServer();
     }
   }
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportIntegrationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportIntegrationTest.java
@@ -155,6 +155,27 @@ class HttpServerTransportIntegrationTest {
   }
 
   @Test
+  void should_reject_tokenless_mcp_with_disallowed_origin_via_auth_layer() throws Exception {
+    httpServer.startServer().join();
+    await().atMost(5, TimeUnit.SECONDS).until(() -> isServerRunning(httpServer.getServerUrl()));
+
+    try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
+      var request = HttpRequest.newBuilder()
+        .uri(URI.create(httpServer.getServerUrl()))
+        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+        .header("Content-Type", "application/json")
+        .header("Origin", "https://evil.com")
+        .build();
+
+      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(401);
+      assertThat(response.statusCode()).isNotEqualTo(403);
+      assertThat(response.body()).contains("SonarQube token required");
+    }
+  }
+
+  @Test
   void should_reject_get_requests_with_token() throws Exception {
     httpServer.startServer().join();
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
@@ -263,32 +263,6 @@ class McpSecurityFilterTest {
   }
 
   @Test
-  void should_accept_loopback_origin_on_any_loopback_address() throws Exception {
-    var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
-    when(request.getRequestURI()).thenReturn("/other");
-    when(request.getHeader("Origin")).thenReturn("http://127.0.0.2:8080");
-    when(request.getMethod()).thenReturn("POST");
-
-    filter.doFilter(request, response, filterChain);
-
-    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
-    verify(filterChain).doFilter(request, response);
-  }
-
-  @Test
-  void should_treat_ipv6_loopback_host_binding_as_local() throws Exception {
-    var filter = new McpSecurityFilter("::1", "1.0.0");
-    when(request.getRequestURI()).thenReturn("/other");
-    when(request.getHeader("Origin")).thenReturn("https://external-site.com");
-    when(request.getMethod()).thenReturn("POST");
-
-    filter.doFilter(request, response, filterChain);
-
-    verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
-    verify(filterChain, never()).doFilter(any(), any());
-  }
-
-  @Test
   void should_not_set_origin_header_when_no_origin_and_all_interfaces_binding() throws Exception {
     var filter = new McpSecurityFilter("0.0.0.0", "1.0.0");
     when(request.getHeader("Origin")).thenReturn(null);

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
@@ -96,6 +96,7 @@ class McpSecurityFilterTest {
   @Test
   void should_reject_external_origin_when_bound_to_localhost() throws Exception {
     var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn("https://malicious-site.com");
     when(request.getMethod()).thenReturn("POST");
 
@@ -115,6 +116,7 @@ class McpSecurityFilterTest {
   @Test
   void should_reject_dns_rebinding_attack() throws Exception {
     var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn("http://attacker-controlled-domain.com");
     when(request.getMethod()).thenReturn("POST");
 
@@ -128,6 +130,7 @@ class McpSecurityFilterTest {
   void should_reject_subdomain_bypass_attack_localhost() throws Exception {
     // SECURITY: localhost.evil.com should NOT be allowed just because it starts with "localhost"
     var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn("http://localhost.evil.com");
     when(request.getMethod()).thenReturn("POST");
 
@@ -143,6 +146,7 @@ class McpSecurityFilterTest {
   void should_reject_subdomain_bypass_attack_127() throws Exception {
     // SECURITY: 127.0.0.1.evil.com should NOT be allowed
     var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn("http://127.0.0.1.evil.com");
     when(request.getMethod()).thenReturn("POST");
 
@@ -156,6 +160,7 @@ class McpSecurityFilterTest {
   @MethodSource("allowedOriginScenarios")
   void should_accept_allowed_origins(String hostBinding, String origin, String method) throws Exception {
     var filter = new McpSecurityFilter(hostBinding, "1.0.0");
+    when(request.getRequestURI()).thenReturn(McpSecurityFilter.MCP_ENDPOINT);
     when(request.getHeader("Origin")).thenReturn(origin);
     when(request.getMethod()).thenReturn(method);
 
@@ -194,6 +199,7 @@ class McpSecurityFilterTest {
   @Test
   void should_reject_external_origin_when_bound_to_all_interfaces() throws Exception {
     var filter = new McpSecurityFilter("0.0.0.0", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn("https://external-site.com");
     when(request.getMethod()).thenReturn("POST");
 
@@ -201,6 +207,59 @@ class McpSecurityFilterTest {
 
     verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
     verify(filterChain, never()).doFilter(any(), any());
+  }
+
+  @Test
+  void should_allow_external_origin_when_bearer_token_present() throws Exception {
+    var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn(McpSecurityFilter.MCP_ENDPOINT);
+    when(request.getHeader("Origin")).thenReturn("https://cursor.com");
+    when(request.getHeader("Authorization")).thenReturn("Bearer my-token");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void should_allow_external_origin_on_remote_binding_without_token() throws Exception {
+    var filter = new McpSecurityFilter("api.sonarcloud.io", "1.0.0");
+    when(request.getRequestURI()).thenReturn(McpSecurityFilter.MCP_ENDPOINT);
+    when(request.getHeader("Origin")).thenReturn("https://cursor.com");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void should_allow_oauth_bootstrap_on_mcp_without_token() throws Exception {
+    var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn(McpSecurityFilter.MCP_ENDPOINT);
+    when(request.getHeader("Origin")).thenReturn("https://cursor.com");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void should_allow_well_known_request_without_token() throws Exception {
+    var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/.well-known/oauth-protected-resource");
+    when(request.getHeader("Origin")).thenReturn("https://cursor.com");
+    when(request.getMethod()).thenReturn("GET");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain).doFilter(request, response);
   }
 
   @Test
@@ -261,6 +320,7 @@ class McpSecurityFilterTest {
   @MethodSource("edgeCaseScenarios")
   void should_handle_edge_cases(String hostBinding, String origin, String method, boolean shouldAccept, String description) throws Exception {
     var filter = new McpSecurityFilter(hostBinding, "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn(origin);
     when(request.getMethod()).thenReturn(method);
 
@@ -277,9 +337,9 @@ class McpSecurityFilterTest {
 
   static Stream<Arguments> edgeCaseScenarios() {
     return Stream.of(
-      Arguments.of("127.0.0.1", "", "POST", false, "empty origin header should be rejected"),
+      Arguments.of("127.0.0.1", "", "POST", true, "empty origin header should not be rejected"),
       Arguments.of("localhost", "http://localhost:3000", "POST", true, "localhost binding accepts localhost origins"),
-      Arguments.of("192.168.1.100", "http://localhost:3000", "POST", false, "custom host binding rejects all origins"),
+      Arguments.of("192.168.1.100", "http://localhost:3000", "POST", true, "remote host binding does not enforce origin"),
       Arguments.of("127.0.0.1", "https://malicious.com", "GET", false, "GET with disallowed origin should be rejected"),
       Arguments.of("127.0.0.1", "http://localhost:3000", "POST", true, "POST with allowed origin should be accepted"),
       Arguments.of("0.0.0.0", "https://external-site.com", "POST", false, "0.0.0.0 binding rejects external origins"),
@@ -314,6 +374,7 @@ class McpSecurityFilterTest {
   @Test
   void should_still_reject_unlisted_origin_when_extra_origins_configured() throws Exception {
     var filter = new McpSecurityFilter("127.0.0.1", List.of("https://sonarcloud.io"), "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
     when(request.getHeader("Origin")).thenReturn("https://evil.com");
     when(request.getMethod()).thenReturn("POST");
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/McpSecurityFilterTest.java
@@ -263,6 +263,32 @@ class McpSecurityFilterTest {
   }
 
   @Test
+  void should_accept_loopback_origin_on_any_loopback_address() throws Exception {
+    var filter = new McpSecurityFilter("127.0.0.1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
+    when(request.getHeader("Origin")).thenReturn("http://127.0.0.2:8080");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response, never()).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void should_treat_ipv6_loopback_host_binding_as_local() throws Exception {
+    var filter = new McpSecurityFilter("::1", "1.0.0");
+    when(request.getRequestURI()).thenReturn("/other");
+    when(request.getHeader("Origin")).thenReturn("https://external-site.com");
+    when(request.getMethod()).thenReturn("POST");
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    verify(filterChain, never()).doFilter(any(), any());
+  }
+
+  @Test
   void should_not_set_origin_header_when_no_origin_and_all_interfaces_binding() throws Exception {
     var filter = new McpSecurityFilter("0.0.0.0", "1.0.0");
     when(request.getHeader("Origin")).thenReturn(null);


### PR DESCRIPTION
----
## Summary by Gitar

- **Security updates:**
  - Relaxed `Origin` header enforcement in `McpSecurityFilter` for authenticated requests, OAuth bootstrap paths (`/mcp`), and `/.well-known/*` endpoints.
  - Remote host bindings no longer enforce strict `Origin` checks.
- **Documentation:**
  - Updated `http-authentication-architecture.md` to reflect new origin validation logic and clarify browser-layer backstop role.
- **Testing:**
  - Added integration tests to verify authenticated request bypass and enforcement on non-MCP paths.
  - Updated unit tests to cover new bypass conditions for bootstrap paths and tokens.


<sub>This will update automatically on new commits.</sub>