### PR TITLE
MCP-531 Update CAG to version 0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.15.0.2460
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.16.0.2474
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.14.0.2354
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.15.0.2460
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.21-SNAPSHOT
-sonarContextAugmentationVersion=0.15.0.2460
+sonarContextAugmentationVersion=0.16.0.2474
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.21-SNAPSHOT
-sonarContextAugmentationVersion=0.14.0.2354
+sonarContextAugmentationVersion=0.15.0.2460
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -417,7 +417,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       LOG.debug("CAG entitlement check: could not resolve UUID for org '" + orgKey + "' - skipping CAG");
       return false;
     }
-    var entitlement = api.a3sAnalysisApi().getCagEntitlement(orgUuidV4);
+    var entitlement = api.cagApi().getCagEntitlement(orgUuidV4);
     if (entitlement == null) {
       LOG.debug("CAG entitlement check: could not retrieve entitlement for org '" + orgKey + "' - skipping CAG");
       return false;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/ServerApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/ServerApi.java
@@ -18,6 +18,7 @@ package org.sonarsource.sonarqube.mcp.serverapi;
 
 import org.sonarsource.sonarqube.mcp.serverapi.a3s.A3sAnalysisApi;
 import org.sonarsource.sonarqube.mcp.serverapi.branches.ProjectBranchesApi;
+import org.sonarsource.sonarqube.mcp.serverapi.cag.CagApi;
 import org.sonarsource.sonarqube.mcp.serverapi.components.ComponentsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.duplications.DuplicationsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.enterprises.EnterprisesApi;
@@ -124,6 +125,10 @@ public class ServerApi {
 
   public A3sAnalysisApi a3sAnalysisApi() {
     return new A3sAnalysisApi(helper);
+  }
+
+  public CagApi cagApi() {
+    return new CagApi(helper);
   }
 
   public PullRequestsApi pullRequestsApi() {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/a3s/A3sAnalysisApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/a3s/A3sAnalysisApi.java
@@ -27,7 +27,7 @@ public class A3sAnalysisApi {
 
   public static final String ANALYSES_PATH = "/a3s-analysis/analyses";
   public static final String A3S_ORG_CONFIG_PATH = "/a3s-analysis/org-config/";
-  public static final String CAG_ENTITLEMENT_PATH = "/a3s-analysis/cag-entitlement/";
+  public static final String CAG_ENTITLEMENT_PATH = "/cag/cag-entitlement/";
 
   private static final String JSON_CONTENT_TYPE = "application/json";
   private static final Gson GSON = new Gson();

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/a3s/A3sAnalysisApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/a3s/A3sAnalysisApi.java
@@ -27,7 +27,6 @@ public class A3sAnalysisApi {
 
   public static final String ANALYSES_PATH = "/a3s-analysis/analyses";
   public static final String A3S_ORG_CONFIG_PATH = "/a3s-analysis/org-config/";
-  public static final String CAG_ENTITLEMENT_PATH = "/cag/cag-entitlement/";
 
   private static final String JSON_CONTENT_TYPE = "application/json";
   private static final Gson GSON = new Gson();
@@ -56,19 +55,6 @@ public class A3sAnalysisApi {
     }
   }
 
-  @Nullable
-  public CagEntitlementResponse getCagEntitlement(String organizationUuidV4) {
-    try (var response = helper.getApiSubdomain(CAG_ENTITLEMENT_PATH + organizationUuidV4)) {
-      return GSON.fromJson(response.bodyAsString(), CagEntitlementResponse.class);
-    } catch (Exception e) {
-      LOG.warn("Could not retrieve CAG entitlement for organization '" + organizationUuidV4 + "': " + e.getMessage());
-      return null;
-    }
-  }
-
   public record OrgConfigResponse(String id, boolean enabled, boolean eligible) {
-  }
-
-  public record CagEntitlementResponse(boolean allowed) {
   }
 }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApi.java
@@ -1,0 +1,49 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.serverapi.cag;
+
+import com.google.gson.Gson;
+import jakarta.annotation.Nullable;
+import org.sonarsource.sonarqube.mcp.log.McpLogger;
+import org.sonarsource.sonarqube.mcp.serverapi.ServerApiHelper;
+
+public class CagApi {
+
+  public static final String CAG_ENTITLEMENT_PATH = "/cag/cag-entitlement/";
+
+  private static final Gson GSON = new Gson();
+  private static final McpLogger LOG = McpLogger.getInstance();
+
+  private final ServerApiHelper helper;
+
+  public CagApi(ServerApiHelper helper) {
+    this.helper = helper;
+  }
+
+  @Nullable
+  public CagEntitlementResponse getCagEntitlement(String organizationUuidV4) {
+    try (var response = helper.getApiSubdomain(CAG_ENTITLEMENT_PATH + organizationUuidV4)) {
+      return GSON.fromJson(response.bodyAsString(), CagEntitlementResponse.class);
+    } catch (Exception e) {
+      LOG.warn("Could not retrieve CAG entitlement for organization '" + organizationUuidV4 + "': " + e.getMessage());
+      return null;
+    }
+  }
+
+  public record CagEntitlementResponse(boolean allowed) {
+  }
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/cag/package-info.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/cag/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@ParametersAreNonnullByDefault
+package org.sonarsource.sonarqube.mcp.serverapi.cag;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/org/sonarsource/sonarqube/mcp/harness/SonarQubeMcpServerTestHarness.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/harness/SonarQubeMcpServerTestHarness.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
 import org.sonarsource.sonarqube.mcp.SonarQubeMcpServer;
 import org.sonarsource.sonarqube.mcp.serverapi.a3s.A3sAnalysisApi;
+import org.sonarsource.sonarqube.mcp.serverapi.cag.CagApi;
 import org.sonarsource.sonarqube.mcp.serverapi.features.FeaturesApi;
 import org.sonarsource.sonarqube.mcp.serverapi.organizations.OrganizationsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.plugins.PluginsApi;
@@ -286,8 +287,8 @@ public class SonarQubeMcpServerTestHarness extends TypeBasedParameterResolver<So
       }
 
       // Stub CAG entitlement API — denied by default; tests that need CAG should call stubCagEntitlement(true)
-      if (!mockSonarQubeServer.isStubConfigured(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + orgUuidV4)) {
-        mockSonarQubeServer.stubFor(get(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
+      if (!mockSonarQubeServer.isStubConfigured(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)) {
+        mockSonarQubeServer.stubFor(get(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
           .willReturn(okJson("""
             {"allowed":false}
             """)));
@@ -317,7 +318,7 @@ public class SonarQubeMcpServerTestHarness extends TypeBasedParameterResolver<So
    */
   public void stubCagEntitlement(boolean allowed) {
     var orgUuidV4 = "00000000-0000-0000-0000-000000000001";
-    mockSonarQubeServer.stubFor(get(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
+    mockSonarQubeServer.stubFor(get(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
       .willReturn(okJson("""
         {"allowed":%b}
         """.formatted(allowed))));
@@ -329,7 +330,7 @@ public class SonarQubeMcpServerTestHarness extends TypeBasedParameterResolver<So
    */
   public void stubCagEntitlementError() {
     var orgUuidV4 = "00000000-0000-0000-0000-000000000001";
-    mockSonarQubeServer.stubFor(get(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
+    mockSonarQubeServer.stubFor(get(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
       .willReturn(aResponse().withStatus(500)));
   }
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/a3s/A3sConfigApiTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/a3s/A3sConfigApiTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class A3sConfigApiTest {
 
   private static final String ORG_UUID = "57f08a8b-4a6e-4c64-bf72-83a892472f22";
+  private static final String CAG_ENTITLEMENT_PUBLIC_PATH = "/cag/cag-entitlement/" + ORG_UUID;
 
   @RegisterExtension
   static WireMockExtension sonarqubeMock = WireMockExtension.newInstance()
@@ -100,7 +101,7 @@ class A3sConfigApiTest {
 
   @Test
   void it_should_return_cag_entitlement_when_org_is_allowed() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + ORG_UUID))
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(jsonResponse("""
         {"allowed":true}
         """, 200)));
@@ -113,7 +114,7 @@ class A3sConfigApiTest {
 
   @Test
   void it_should_return_cag_entitlement_when_org_is_denied() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + ORG_UUID))
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(jsonResponse("""
         {"allowed":false}
         """, 200)));
@@ -126,7 +127,7 @@ class A3sConfigApiTest {
 
   @Test
   void it_should_ignore_cag_entitlement_consumption() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + ORG_UUID))
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(jsonResponse("""
         {"allowed":true,"consumption":{"consumed":500,"limit":1000}}
         """, 200)));
@@ -139,7 +140,7 @@ class A3sConfigApiTest {
 
   @Test
   void it_should_return_null_on_cag_entitlement_server_error() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + ORG_UUID))
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(aResponse().withStatus(500)));
 
     var entitlement = a3sAnalysisApi.getCagEntitlement(ORG_UUID);
@@ -149,7 +150,7 @@ class A3sConfigApiTest {
 
   @Test
   void it_should_return_null_on_cag_entitlement_not_found() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.CAG_ENTITLEMENT_PATH + ORG_UUID))
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(aResponse().withStatus(404)));
 
     var entitlement = a3sAnalysisApi.getCagEntitlement(ORG_UUID);

--- a/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApiTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApiTest.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the Sonar Source-Available License
  * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
-package org.sonarsource.sonarqube.mcp.serverapi.a3s;
+package org.sonarsource.sonarqube.mcp.serverapi.cag;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,69 +33,81 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class A3sConfigApiTest {
+class CagApiTest {
 
   private static final String ORG_UUID = "57f08a8b-4a6e-4c64-bf72-83a892472f22";
+  private static final String CAG_ENTITLEMENT_PUBLIC_PATH = "/cag/cag-entitlement/" + ORG_UUID;
 
   @RegisterExtension
   static WireMockExtension sonarqubeMock = WireMockExtension.newInstance()
     .options(wireMockConfig().dynamicPort())
     .build();
 
-  private A3sAnalysisApi a3sAnalysisApi;
+  private CagApi cagApi;
 
   @BeforeAll
   void init() {
     var httpClient = new HttpClientProvider("test").getHttpClient("token");
     var helper = new ServerApiHelper(new EndpointParams(sonarqubeMock.baseUrl(), "my-org", null, true), httpClient);
-    a3sAnalysisApi = new A3sAnalysisApi(helper);
+    cagApi = new CagApi(helper);
   }
 
   @Test
-  void it_should_return_a3s_config_when_org_is_enabled() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.A3S_ORG_CONFIG_PATH + ORG_UUID))
+  void it_should_return_cag_entitlement_when_org_is_allowed() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(jsonResponse("""
-        {"id":"%s","enabled":true,"eligible":true}
-        """.formatted(ORG_UUID), 200)));
+        {"allowed":true}
+        """, 200)));
 
-    var config = a3sAnalysisApi.getA3sOrgConfig(ORG_UUID);
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
 
-    assertThat(config).isNotNull();
-    assertThat(config.enabled()).isTrue();
-    assertThat(config.eligible()).isTrue();
+    assertThat(entitlement).isNotNull();
+    assertThat(entitlement.allowed()).isTrue();
   }
 
   @Test
-  void it_should_return_a3s_config_when_org_is_disabled() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.A3S_ORG_CONFIG_PATH + ORG_UUID))
+  void it_should_return_cag_entitlement_when_org_is_denied() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(jsonResponse("""
-        {"id":"%s","enabled":false,"eligible":true}
-        """.formatted(ORG_UUID), 200)));
+        {"allowed":false}
+        """, 200)));
 
-    var config = a3sAnalysisApi.getA3sOrgConfig(ORG_UUID);
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
 
-    assertThat(config).isNotNull();
-    assertThat(config.enabled()).isFalse();
+    assertThat(entitlement).isNotNull();
+    assertThat(entitlement.allowed()).isFalse();
   }
 
   @Test
-  void it_should_return_null_on_a3s_server_error() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.A3S_ORG_CONFIG_PATH + ORG_UUID))
+  void it_should_ignore_cag_entitlement_consumption() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
+      .willReturn(jsonResponse("""
+        {"allowed":true,"consumption":{"consumed":500,"limit":1000}}
+        """, 200)));
+
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
+
+    assertThat(entitlement).isNotNull();
+    assertThat(entitlement.allowed()).isTrue();
+  }
+
+  @Test
+  void it_should_return_null_on_cag_entitlement_server_error() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(aResponse().withStatus(500)));
 
-    var config = a3sAnalysisApi.getA3sOrgConfig(ORG_UUID);
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
 
-    assertThat(config).isNull();
+    assertThat(entitlement).isNull();
   }
 
   @Test
-  void it_should_return_null_on_a3s_not_found() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(A3sAnalysisApi.A3S_ORG_CONFIG_PATH + ORG_UUID))
+  void it_should_return_null_on_cag_entitlement_not_found() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(aResponse().withStatus(404)));
 
-    var config = a3sAnalysisApi.getA3sOrgConfig(ORG_UUID);
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
 
-    assertThat(config).isNull();
+    assertThat(entitlement).isNull();
   }
-
 }


### PR DESCRIPTION
 - Use the CAG API route for cag-entitlement: The CAG endpoint is now accessible via a CAG-specific route /cag. See SC-51074 for more details.
 - Split `CagApi` out of `A3sAnalysisApi` now that there is a dedicated public route for CAG.
 - Update CAG to 0.16.0