### PR TITLE
MCP-536 Skip SCA feature-enabled check when organization is unavailable

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/sca/ScaApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/sca/ScaApi.java
@@ -35,8 +35,12 @@ public class ScaApi {
   }
 
   public boolean isScaEnabled() {
+    var organization = helper.getOrganization();
+    if (organization == null || organization.isBlank()) {
+      return false;
+    }
     var path = new UrlBuilder(FEATURE_ENABLED_PATH)
-      .addParam("organization", helper.getOrganization())
+      .addParam("organization", organization)
       .build();
     try (var response = helper.getApiSubdomain(path)) {
       var responseStr = response.bodyAsString();


### PR DESCRIPTION
## Summary
- `ScaApi.isScaEnabled()` now returns `false` immediately when no organization is configured, instead of calling `/sca/feature-enabled` with an empty query string.

## Test plan
- [x] `./gradlew compileJava compileTestJava`
- [x] `./gradlew test --tests "*SearchDependencyRisksToolTests*"`