### PR TITLE
MCP-545 Support short-lived branches in list_branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,9 +1059,12 @@ SOCKS5 proxies are supported.
   - `q` - Optional search query to filter projects by name (partial match) or key (exact match) - _String_
 
 
-- **list_branches** - List analyzed branches for a project (long-lived and short-lived). On SonarQube Cloud, returns `LONG` (main, develop) and `SHORT` (feature branches without PR) branches. On SonarQube Server, returns `BRANCH` entries. Use returned names as the `branch` parameter on other tools. For pull request analysis, use `list_pull_requests` instead.
+- **list_branches** - List analyzed branches for a project.
+  - **SonarQube Cloud**: returns long-lived (`LONG`) and short-lived (`SHORT`) branches with `type` and `mergeBranch` fields. Optional `branchTypes` filter: `ALL` (default), `LONG`, or `SHORT`.
+  - **SonarQube Server**: returns all analyzed branches (name, quality gate, analysis date). No `type`, `mergeBranch`, or `branchTypes` filter.
+  - Use returned branch names as the `branch` parameter on other tools. For pull request analysis, use `list_pull_requests` instead.
   - `projectKey` - Project key (e.g. my_project) - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `branchTypes` - Optional filter: `ALL` (default), `LONG`, or `SHORT` (SonarQube Cloud only) - _Enum {"ALL", "LONG", "SHORT"}_
+  - `branchTypes` - _(SonarQube Cloud only)_ Optional filter: `ALL` (default), `LONG`, or `SHORT` - _Enum {"ALL", "LONG", "SHORT"}_
 
 
 - **list_pull_requests** - List all pull requests for a project. Use this tool to discover pull requests for PR-decorated analysis (coverage, issues, quality gate). Returns the pull request key/ID which can be used with other tools. For branch-based analysis without pull requests, use `list_branches` instead.

--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ SOCKS5 proxies are supported.
 
 - **search_files_by_coverage** - Search for files in a project sorted by coverage (ascending - worst coverage first). This tool helps identify files that need test coverage improvements.
   - `projectKey` - The project key to search in - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `maxCoverage` - Maximum coverage threshold (0-100). Only return files with coverage <= this value - _Number_
   - `pageIndex` - Page index (1-based, default: 1) - _Number_
@@ -947,7 +947,7 @@ SOCKS5 proxies are supported.
 
 - **get_file_coverage_details** - Get line-by-line coverage information for a specific file, including which exact lines are uncovered and which have partially covered branches. This tool helps identify precisely where to add test coverage. Use after identifying files with low coverage via search_files_by_coverage.
   - `key` - File key (e.g. my_project:src/foo/Bar.java) - _Required String_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `from` - First line to analyze (1-based, default: 1) - _Number_
   - `to` - Last line to analyze (inclusive). If not specified, all lines are returned - _Number_
@@ -958,7 +958,7 @@ SOCKS5 proxies are supported.
 
 - **search_dependency_risks** - Search for software composition analysis issues (dependency risks) of a SonarQube project, paired with releases that appear in the analyzed project, application, or portfolio.
   - `projectKey` - Project key - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `pageIndex` - Optional page index (1-based, default: 1) - _Integer_
   - `pageSize` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
@@ -979,7 +979,7 @@ SOCKS5 proxies are supported.
 
 - **search_sonar_issues_in_projects** - Search for SonarQube issues in my organization's projects.
   - `projectKeys` - Optional list of SonarQube project keys - _String[]_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `severities` - Optional list of severities to filter by. Possible values: INFO, LOW, MEDIUM, HIGH, BLOCKER - _String[]_
   - `impactSoftwareQualities` - Optional list of software qualities to filter by. Possible values: MAINTAINABILITY, RELIABILITY, SECURITY - _String[]_
@@ -993,7 +993,7 @@ SOCKS5 proxies are supported.
 - **search_security_hotspots** - Search for Security Hotspots in a SonarQube project.
   - `projectKey` - Project or application key - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
   - `hotspotKeys` - Comma-separated list of specific Security Hotspot keys to retrieve - _String[]_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `files` - Optional list of file paths to filter - _String[]_
   - `status` - Optional status filter: TO_REVIEW, REVIEWED - _String_
@@ -1023,7 +1023,7 @@ SOCKS5 proxies are supported.
 
 - **get_component_measures** - Get SonarQube measures for a component (project, directory, file).
   - `projectKey` - The project key - _Required String when `SONARQUBE_PROJECT_KEY` is not configured_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `metricKeys` - Optional metric keys to retrieve (e.g. ncloc, complexity, violations, coverage) - _String[]_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
@@ -1059,18 +1059,19 @@ SOCKS5 proxies are supported.
   - `q` - Optional search query to filter projects by name (partial match) or key (exact match) - _String_
 
 
-- **list_branches** - List long-lived branches for a project (e.g. main, develop, master). Returns only `LONG` branches on SonarQube Cloud and `BRANCH` entries on SonarQube Server — names safe for the `branch` parameter on other tools. For pull requests, use `list_pull_requests` instead.
+- **list_branches** - List analyzed branches for a project (long-lived and short-lived). On SonarQube Cloud, returns `LONG` (main, develop) and `SHORT` (feature branches without PR) branches. On SonarQube Server, returns `BRANCH` entries. Use returned names as the `branch` parameter on other tools. For pull request analysis, use `list_pull_requests` instead.
   - `projectKey` - Project key (e.g. my_project) - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
+  - `branchTypes` - Optional filter: `ALL` (default), `LONG`, or `SHORT` (SonarQube Cloud only) - _Enum {"ALL", "LONG", "SHORT"}_
 
 
-- **list_pull_requests** - List all pull requests for a project. Use this tool to discover available pull requests before analyzing their coverage, issues, or quality. Returns the pull request key/ID which can be used with other tools (e.g., search_files_by_coverage, get_file_coverage_details). For long-lived branches, use `list_branches` instead.
+- **list_pull_requests** - List all pull requests for a project. Use this tool to discover pull requests for PR-decorated analysis (coverage, issues, quality gate). Returns the pull request key/ID which can be used with other tools. For branch-based analysis without pull requests, use `list_branches` instead.
   - `projectKey` - Project key (e.g. my_project) - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
 
 ### Quality Gates
 
 - **get_project_quality_gate_status** - Get the Quality Gate Status for the SonarQube project.
   - `analysisId` - Optional analysis ID - _String_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `projectId` - Optional project ID - _String_
   - `projectKey` - Optional project key - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
@@ -1087,7 +1088,7 @@ SOCKS5 proxies are supported.
 
 - **search_duplicated_files** - Search for files with code duplications in a SonarQube project. By default, automatically fetches all duplicated files across all pages (up to 10,000 files max). Returns only files with duplications.
   - `projectKey` - Project key - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `pageSize` - Optional number of results per page for manual pagination (max: 500). If not specified, auto-fetches all duplicated files - _Integer_
   - `pageIndex` - Optional page number for manual pagination (starts at 1). If not specified, auto-fetches all duplicated files - _Integer_
@@ -1095,14 +1096,14 @@ SOCKS5 proxies are supported.
 
 - **get_duplications** - Get duplications for a file. Require Browse permission on file's project.
   - `key` - File key - _Required String_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
 ### Sources
 
 - **get_raw_source** - Get source code as raw text from SonarQube. Require 'See Source Code' permission on file.
   - `key` - File key - _Required String_
-  - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
+  - `branch` - Optional branch name for branch-based analysis. Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
 
 

--- a/agent_configurations/kiro_power/POWER.md
+++ b/agent_configurations/kiro_power/POWER.md
@@ -116,13 +116,20 @@ search_sonar_issues_in_projects({
 
 ### Branch vs Pull Request Context
 
-- **Long-lived branches** (main, develop): use `branch`. Discover names with `list_branches`.
-- **Pull requests / feature branches**: use `pullRequest`. Discover keys with `list_pull_requests`.
+SonarQube Cloud has three analysis contexts: long-lived branches, short-lived branches, and pull requests. SonarQube Server has branch and pull request only.
+
+- **Branch-based analysis** (long-lived or short-lived without PR): use `branch`. Discover names with `list_branches` (type `LONG` for main/develop, type `SHORT` for feature branches on Cloud). You can also pass the current git branch name directly.
+- **Pull request analysis**: use `pullRequest`. Discover keys with `list_pull_requests`.
+- If the user is working on a pull request, prefer `pullRequest`. Otherwise use `branch`.
 - Never pass a git branch name to a `pullRequest` parameter.
 
 ```javascript
+// Analyze a short-lived branch without PR
+list_branches({ projectKey: "my-project", branchTypes: "SHORT" });
+search_sonar_issues_in_projects({ projects: ["my-project"], branch: "feature/my-fix" });
+
 // Compare quality gate on develop vs main
-list_branches({ projectKey: "my-project" });
+list_branches({ projectKey: "my-project", branchTypes: "LONG" });
 get_project_quality_gate_status({ projectKey: "my-project", branch: "develop" });
 
 // Analyze an open pull request

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -111,18 +111,26 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     5. If no key is found, use `search_my_sonarqube_projects` to list projects.
     An incorrect project key will silently return results from the wrong project.
     """;
-  private static final String BRANCH_PULL_REQUEST_INSTRUCTIONS = """
-    ## Branch vs Pull Request Context
-    SonarQube Cloud has three analysis contexts: long-lived branches, short-lived branches, and pull requests. \
-    SonarQube Server has branch and pull request only (no long/short distinction).
-    - Branch-based analysis (long-lived or short-lived without PR): use `branch`. Discover names with `list_branches` \
-    (type LONG for main/develop, type SHORT for feature branches on Cloud). You can also pass the current git branch name directly.
-    - Pull request analysis: use `pullRequest`. Discover keys with `list_pull_requests`.
-    - If the user is working on a pull request, prefer `pullRequest`. Otherwise use `branch`.
+  private static final String BRANCH_PULL_REQUEST_INSTRUCTIONS_COMMON = """
     - Never pass a git branch name to a pullRequest parameter — it expects the SonarQube PR key.
     - Never provide both branch and pullRequest on the same call.
     - Omit both to query the default (main) branch analysis.
     """;
+  private static final String BRANCH_PULL_REQUEST_INSTRUCTIONS_CLOUD = """
+    ## Branch vs Pull Request Context
+    SonarQube Cloud has three analysis contexts: long-lived branches, short-lived branches, and pull requests.
+    - Long-lived branches (main, develop): use `branch`. Discover with `list_branches` (type LONG) or `branchTypes=LONG`.
+    - Short-lived branches (no PR): use `branch`. Discover via `list_branches` (SHORT) or `branchTypes=SHORT`; git branch name also works.
+    - Pull request analysis: use `pullRequest`. Discover keys with `list_pull_requests`.
+    - If the user is working on a pull request, prefer `pullRequest`. Otherwise use `branch`.
+    """ + BRANCH_PULL_REQUEST_INSTRUCTIONS_COMMON;
+  private static final String BRANCH_PULL_REQUEST_INSTRUCTIONS_SERVER = """
+    ## Branch vs Pull Request Context
+    SonarQube Server has two analysis contexts: branches and pull requests.
+    - Branch analysis: use `branch`. Discover names with `list_branches`, or pass the current git branch name directly.
+    - Pull request analysis: use `pullRequest`. Discover keys with `list_pull_requests`.
+    - If the user is working on a pull request, prefer `pullRequest`. Otherwise use `branch`.
+    """ + BRANCH_PULL_REQUEST_INSTRUCTIONS_COMMON;
   private static final String BASE_INSTRUCTIONS_WITH_ANALYSIS = "Transform your code quality workflow with SonarQube integration. " +
     "Analyze code, monitor project health, investigate issues, and understand quality gates. " +
     "Note: Analyzers are being downloaded in the background and will be available shortly for code analysis.";
@@ -555,7 +563,9 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     composedInstructions = mcpConfiguration.isToolCategoryEnabled(ToolCategory.ANALYSIS)
       ? BASE_INSTRUCTIONS_WITH_ANALYSIS
       : BASE_INSTRUCTIONS_WITHOUT_ANALYSIS;
-    composedInstructions += "\n" + BRANCH_PULL_REQUEST_INSTRUCTIONS;
+    composedInstructions += "\n" + (mcpConfiguration.isSonarQubeCloud()
+      ? BRANCH_PULL_REQUEST_INSTRUCTIONS_CLOUD
+      : BRANCH_PULL_REQUEST_INSTRUCTIONS_SERVER);
     if (mcpConfiguration.getProjectKey() == null) {
       composedInstructions += "\n" + PROJECT_KEY_INSTRUCTIONS;
     }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -414,7 +414,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       new SearchDuplicatedFilesTool(this, configuredProjectKey),
       new ListPortfoliosTool(this, mcpConfiguration.isSonarQubeCloud()),
       new ListPullRequestsTool(this, configuredProjectKey),
-      new ListBranchesTool(this, configuredProjectKey)));
+      new ListBranchesTool(this, mcpConfiguration.isSonarQubeCloud(), configuredProjectKey)));
 
     if (mcpConfiguration.isHttpEnabled()) {
       // In HTTP mode there is no startup token to probe SCA availability

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -113,8 +113,12 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     """;
   private static final String BRANCH_PULL_REQUEST_INSTRUCTIONS = """
     ## Branch vs Pull Request Context
-    - Long-lived branches (main, develop, release/*): use `branch`. Discover names with `list_branches`.
-    - Pull requests / feature branches: use `pullRequest`. Discover keys with `list_pull_requests`.
+    SonarQube Cloud has three analysis contexts: long-lived branches, short-lived branches, and pull requests. \
+    SonarQube Server has branch and pull request only (no long/short distinction).
+    - Branch-based analysis (long-lived or short-lived without PR): use `branch`. Discover names with `list_branches` \
+    (type LONG for main/develop, type SHORT for feature branches on Cloud). You can also pass the current git branch name directly.
+    - Pull request analysis: use `pullRequest`. Discover keys with `list_pull_requests`.
+    - If the user is working on a pull request, prefer `pullRequest`. Otherwise use `branch`.
     - Never pass a git branch name to a pullRequest parameter — it expects the SonarQube PR key.
     - Never provide both branch and pullRequest on the same call.
     - Omit both to query the default (main) branch analysis.

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/BranchesListResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/branches/response/BranchesListResponse.java
@@ -27,7 +27,8 @@ public record BranchesListResponse(List<Branch> branches) {
     String type,
     @Nullable Status status,
     @Nullable String analysisDate,
-    String branchId
+    String branchId,
+    @Nullable String mergeBranch
   ) {
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContext.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/BranchPullRequestContext.java
@@ -25,12 +25,12 @@ public final class BranchPullRequestContext {
   public static final String PULL_REQUEST_PROPERTY = "pullRequest";
 
   public static final String BRANCH_PROPERTY_DESCRIPTION = """
-    Long-lived branch name in SonarQube (e.g. 'main', 'develop'). Use list_branches to discover valid names. \
-    Not for feature branches or pull request analysis — use pullRequest instead.""";
+    Branch name for branch-based analysis. Discover names with list_branches. \
+    For pull request analysis, use pullRequest instead.""";
 
   public static final String PULL_REQUEST_PROPERTY_DESCRIPTION = """
-    Pull request key/ID in SonarQube. Use list_pull_requests to discover valid keys. \
-    Not for long-lived branches — use branch instead. Must be the SonarQube PR key, not a git branch name.""";
+    Pull request key/ID in SonarQube for PR-decorated analysis. Use list_pull_requests to discover valid keys. \
+    For branch-based analysis (long-lived or short-lived without PR), use branch instead. Must be the SonarQube PR key, not a git branch name.""";
 
   private BranchPullRequestContext() {
     // utility class
@@ -51,8 +51,8 @@ public final class BranchPullRequestContext {
   public static Optional<Tool.Result> validateMutualExclusion(@Nullable String branch, @Nullable String pullRequest) {
     if (branch != null && pullRequest != null) {
       return Optional.of(Tool.Result.failure(
-        "Cannot use 'branch' and 'pullRequest' together. Use 'branch' for long-lived branches (see list_branches) "
-          + "or 'pullRequest' for pull requests (see list_pull_requests)."));
+        "Cannot use 'branch' and 'pullRequest' together. Use 'branch' for branch-based analysis (see list_branches) "
+          + "or 'pullRequest' for pull request analysis (see list_pull_requests)."));
     }
     return Optional.empty();
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/BranchTypes.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/BranchTypes.java
@@ -32,8 +32,23 @@ public final class BranchTypes {
     // utility class
   }
 
+  static final String[] BRANCH_TYPES_FILTER_VALUES = {"ALL", "LONG", "SHORT"};
+
   public static boolean isLongLivedBranchType(@Nullable String type) {
     return "LONG".equals(type) || "BRANCH".equals(type);
+  }
+
+  public static boolean matchesBranchTypesFilter(@Nullable String type, @Nullable String filter) {
+    if (filter == null || "ALL".equals(filter)) {
+      return true;
+    }
+    if ("LONG".equals(filter)) {
+      return isLongLivedBranchType(type);
+    }
+    if ("SHORT".equals(filter)) {
+      return "SHORT".equals(type);
+    }
+    return true;
   }
 
   @Nullable

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/BranchTypes.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/BranchTypes.java
@@ -20,8 +20,8 @@ import jakarta.annotation.Nullable;
 
 public final class BranchTypes {
 
-  public enum BranchType {
-    LONG, SHORT, BRANCH
+  public enum CloudBranchType {
+    LONG, SHORT
   }
 
   public enum QualityGateStatus {
@@ -48,16 +48,16 @@ public final class BranchTypes {
     if ("SHORT".equals(filter)) {
       return "SHORT".equals(type);
     }
-    return true;
+    return false;
   }
 
   @Nullable
-  public static BranchType parseBranchType(@Nullable String type) {
+  public static CloudBranchType parseCloudBranchType(@Nullable String type) {
     if (type == null) {
       return null;
     }
     try {
-      return BranchType.valueOf(type);
+      return CloudBranchType.valueOf(type);
     } catch (IllegalArgumentException e) {
       return null;
     }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
@@ -27,7 +27,7 @@ import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.BRANCH_TYPES_FILTER_VALUES;
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.matchesBranchTypesFilter;
-import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseBranchType;
+import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseCloudBranchType;
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseQualityGateStatus;
 
 public class ListBranchesTool extends Tool {
@@ -96,7 +96,7 @@ public class ListBranchesTool extends Tool {
       .map(branch -> new ListBranchesToolCloudResponse.Branch(
         branch.name(),
         branch.isMain(),
-        parseBranchType(branch.type()),
+        parseCloudBranchType(branch.type()),
         branch.status() != null ? parseQualityGateStatus(branch.status().qualityGateStatus()) : null,
         branch.analysisDate(),
         branch.branchId(),

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
@@ -16,8 +16,10 @@
  */
 package org.sonarsource.sonarqube.mcp.tools.branches;
 
+import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
+import org.sonarsource.sonarqube.mcp.serverapi.branches.response.BranchesListResponse;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -34,38 +36,64 @@ public class ListBranchesTool extends Tool {
   public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String BRANCH_TYPES_PROPERTY = "branchTypes";
 
+  private static final String CLOUD_DESCRIPTION = "List analyzed branches for a SonarQube Cloud project (long-lived and short-lived). " +
+    "Use returned branch names as the branch parameter on other tools (e.g. get_project_quality_gate_status, get_component_measures). " +
+    "Check the type field: LONG for main/develop, SHORT for feature branches analyzed without pull requests. " +
+    "For pull request analysis, use list_pull_requests instead.";
+
+  private static final String SERVER_DESCRIPTION = "List analyzed branches for a SonarQube Server project. " +
+    "Use returned branch names as the branch parameter on other tools (e.g. get_project_quality_gate_status, get_component_measures). " +
+    "For pull request analysis, use list_pull_requests instead.";
+
   private final ServerApiProvider serverApiProvider;
+  private final boolean isSonarQubeCloud;
   @Nullable
   private final String configuredProjectKey;
 
-  public ListBranchesTool(ServerApiProvider serverApiProvider, @Nullable String configuredProjectKey) {
-    super(SchemaToolBuilder.forOutput(ListBranchesToolResponse.class)
-        .setName(TOOL_NAME)
-        .setTitle("List SonarQube Branches")
-        .setDescription("List analyzed branches for a project (long-lived and short-lived). " +
-          "Use returned branch names as the branch parameter on other tools (e.g. get_project_quality_gate_status, get_component_measures). " +
-          "On SonarQube Cloud, check the type field: LONG for main/develop, SHORT for feature branches analyzed without pull requests. " +
-          "For pull request analysis, use list_pull_requests instead.")
-        .addProjectKeyProperty(PROJECT_KEY_PROPERTY, configuredProjectKey)
-        .addEnumProperty(BRANCH_TYPES_PROPERTY, BRANCH_TYPES_FILTER_VALUES,
-          "Filter branches by type. ALL (default) returns all analyzed branches; LONG returns long-lived branches only; SHORT returns short-lived branches only (SonarQube Cloud).")
-        .setReadOnlyHint()
-        .build(),
+  public ListBranchesTool(ServerApiProvider serverApiProvider, boolean isSonarQubeCloud, @Nullable String configuredProjectKey) {
+    super(createToolDefinition(isSonarQubeCloud, configuredProjectKey),
       ToolCategory.PROJECTS);
     this.serverApiProvider = serverApiProvider;
+    this.isSonarQubeCloud = isSonarQubeCloud;
     this.configuredProjectKey = configuredProjectKey;
+  }
+
+  private static McpSchema.Tool createToolDefinition(boolean isSonarQubeCloud, @Nullable String configuredProjectKey) {
+    var builder = isSonarQubeCloud
+      ? SchemaToolBuilder.forOutput(ListBranchesToolCloudResponse.class)
+      : SchemaToolBuilder.forOutput(ListBranchesToolServerResponse.class);
+
+    builder.setName(TOOL_NAME)
+      .setTitle("List SonarQube Branches")
+      .setDescription(isSonarQubeCloud ? CLOUD_DESCRIPTION : SERVER_DESCRIPTION)
+      .addProjectKeyProperty(PROJECT_KEY_PROPERTY, configuredProjectKey);
+
+    if (isSonarQubeCloud) {
+      builder.addEnumProperty(BRANCH_TYPES_PROPERTY, BRANCH_TYPES_FILTER_VALUES,
+        "Filter branches by type. ALL (default) returns all analyzed branches; LONG returns long-lived branches only; SHORT returns short-lived branches only.");
+    }
+
+    return builder.setReadOnlyHint().build();
   }
 
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
-    var branchTypesFilter = arguments.getOptionalEnumValue(BRANCH_TYPES_PROPERTY, BRANCH_TYPES_FILTER_VALUES);
 
     var response = serverApiProvider.get().projectBranchesApi().listBranches(projectKey);
 
+    if (isSonarQubeCloud) {
+      return executeForCloud(arguments, projectKey, response);
+    }
+    return executeForServer(projectKey, response);
+  }
+
+  private static Tool.Result executeForCloud(Tool.Arguments arguments, String projectKey, BranchesListResponse response) {
+    var branchTypesFilter = arguments.getOptionalEnumValue(BRANCH_TYPES_PROPERTY, BRANCH_TYPES_FILTER_VALUES);
+
     var branches = response.branches().stream()
       .filter(branch -> matchesBranchTypesFilter(branch.type(), branchTypesFilter))
-      .map(branch -> new ListBranchesToolResponse.Branch(
+      .map(branch -> new ListBranchesToolCloudResponse.Branch(
         branch.name(),
         branch.isMain(),
         parseBranchType(branch.type()),
@@ -76,13 +104,21 @@ public class ListBranchesTool extends Tool {
       ))
       .toList();
 
-    var toolResponse = new ListBranchesToolResponse(
-      projectKey,
-      branches.size(),
-      branches
-    );
+    return Tool.Result.success(new ListBranchesToolCloudResponse(projectKey, branches.size(), branches));
+  }
 
-    return Tool.Result.success(toolResponse);
+  private static Tool.Result executeForServer(String projectKey, BranchesListResponse response) {
+    var branches = response.branches().stream()
+      .map(branch -> new ListBranchesToolServerResponse.Branch(
+        branch.name(),
+        branch.isMain(),
+        branch.status() != null ? parseQualityGateStatus(branch.status().qualityGateStatus()) : null,
+        branch.analysisDate(),
+        branch.branchId()
+      ))
+      .toList();
+
+    return Tool.Result.success(new ListBranchesToolServerResponse(projectKey, branches.size(), branches));
   }
 
 }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
@@ -23,7 +23,8 @@ import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
 import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
-import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.isLongLivedBranchType;
+import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.BRANCH_TYPES_FILTER_VALUES;
+import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.matchesBranchTypesFilter;
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseBranchType;
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseQualityGateStatus;
 
@@ -31,6 +32,7 @@ public class ListBranchesTool extends Tool {
 
   public static final String TOOL_NAME = "list_branches";
   public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
+  public static final String BRANCH_TYPES_PROPERTY = "branchTypes";
 
   private final ServerApiProvider serverApiProvider;
   @Nullable
@@ -40,10 +42,13 @@ public class ListBranchesTool extends Tool {
     super(SchemaToolBuilder.forOutput(ListBranchesToolResponse.class)
         .setName(TOOL_NAME)
         .setTitle("List SonarQube Branches")
-        .setDescription("List long-lived branches for a project (e.g. main, develop, master). " +
+        .setDescription("List analyzed branches for a project (long-lived and short-lived). " +
           "Use returned branch names as the branch parameter on other tools (e.g. get_project_quality_gate_status, get_component_measures). " +
-          "For pull requests, use list_pull_requests instead.")
+          "On SonarQube Cloud, check the type field: LONG for main/develop, SHORT for feature branches analyzed without pull requests. " +
+          "For pull request analysis, use list_pull_requests instead.")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, configuredProjectKey)
+        .addEnumProperty(BRANCH_TYPES_PROPERTY, BRANCH_TYPES_FILTER_VALUES,
+          "Filter branches by type. ALL (default) returns all analyzed branches; LONG returns long-lived branches only; SHORT returns short-lived branches only (SonarQube Cloud).")
         .setReadOnlyHint()
         .build(),
       ToolCategory.PROJECTS);
@@ -54,18 +59,20 @@ public class ListBranchesTool extends Tool {
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
     var projectKey = arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey);
+    var branchTypesFilter = arguments.getOptionalEnumValue(BRANCH_TYPES_PROPERTY, BRANCH_TYPES_FILTER_VALUES);
 
     var response = serverApiProvider.get().projectBranchesApi().listBranches(projectKey);
 
     var branches = response.branches().stream()
-      .filter(branch -> isLongLivedBranchType(branch.type()))
+      .filter(branch -> matchesBranchTypesFilter(branch.type(), branchTypesFilter))
       .map(branch -> new ListBranchesToolResponse.Branch(
         branch.name(),
         branch.isMain(),
         parseBranchType(branch.type()),
         branch.status() != null ? parseQualityGateStatus(branch.status().qualityGateStatus()) : null,
         branch.analysisDate(),
-        branch.branchId()
+        branch.branchId(),
+        branch.mergeBranch()
       ))
       .toList();
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolCloudResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolCloudResponse.java
@@ -19,7 +19,7 @@ package org.sonarsource.sonarqube.mcp.tools.branches;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import jakarta.annotation.Nullable;
-import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.BranchType;
+import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.CloudBranchType;
 import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.QualityGateStatus;
 
 public record ListBranchesToolCloudResponse(
@@ -31,7 +31,7 @@ public record ListBranchesToolCloudResponse(
   public record Branch(
     @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
     @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
-    @JsonPropertyDescription("Branch type: LONG for main/develop, SHORT for feature branches analyzed without pull requests") @Nullable BranchType type,
+    @JsonPropertyDescription("Branch type: LONG for main/develop, SHORT for feature branches analyzed without pull requests") @Nullable CloudBranchType type,
     @JsonPropertyDescription("Quality gate status for this branch") @Nullable QualityGateStatus qualityGateStatus,
     @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
     @JsonPropertyDescription("Internal branch identifier") String branchId,

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolCloudResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolCloudResponse.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.BranchType;
 import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.QualityGateStatus;
 
-public record ListBranchesToolResponse(
+public record ListBranchesToolCloudResponse(
   @JsonPropertyDescription("Project key") String projectKey,
   @JsonPropertyDescription("Total number of branches") int totalBranches,
   @JsonPropertyDescription("List of branches for this project") List<Branch> branches
@@ -31,11 +31,11 @@ public record ListBranchesToolResponse(
   public record Branch(
     @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
     @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
-    @JsonPropertyDescription("Branch type in SonarQube (LONG or SHORT on SonarQube Cloud, BRANCH on SonarQube Server)") @Nullable BranchType type,
+    @JsonPropertyDescription("Branch type: LONG for main/develop, SHORT for feature branches analyzed without pull requests") @Nullable BranchType type,
     @JsonPropertyDescription("Quality gate status for this branch") @Nullable QualityGateStatus qualityGateStatus,
     @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
     @JsonPropertyDescription("Internal branch identifier") String branchId,
-    @JsonPropertyDescription("Target branch for short-lived branches on SonarQube Cloud (e.g. main, master)") @Nullable String mergeBranch
+    @JsonPropertyDescription("Target branch for short-lived branches (e.g. main, master)") @Nullable String mergeBranch
   ) {
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolResponse.java
@@ -31,10 +31,11 @@ public record ListBranchesToolResponse(
   public record Branch(
     @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
     @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
-    @JsonPropertyDescription("Branch type in SonarQube (LONG on SonarQube Cloud, BRANCH on SonarQube Server)") @Nullable BranchType type,
+    @JsonPropertyDescription("Branch type in SonarQube (LONG or SHORT on SonarQube Cloud, BRANCH on SonarQube Server)") @Nullable BranchType type,
     @JsonPropertyDescription("Quality gate status for this branch") @Nullable QualityGateStatus qualityGateStatus,
     @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
-    @JsonPropertyDescription("Internal branch identifier") String branchId
+    @JsonPropertyDescription("Internal branch identifier") String branchId,
+    @JsonPropertyDescription("Target branch for short-lived branches on SonarQube Cloud (e.g. main, master)") @Nullable String mergeBranch
   ) {
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolServerResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolServerResponse.java
@@ -1,0 +1,39 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools.branches;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+import jakarta.annotation.Nullable;
+import org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.QualityGateStatus;
+
+public record ListBranchesToolServerResponse(
+  @JsonPropertyDescription("Project key") String projectKey,
+  @JsonPropertyDescription("Total number of branches") int totalBranches,
+  @JsonPropertyDescription("List of branches for this project") List<Branch> branches
+) {
+
+  public record Branch(
+    @JsonPropertyDescription("Branch name that can be used with other tools as the branch parameter") String name,
+    @JsonPropertyDescription("Whether this is the main branch") boolean isMain,
+    @JsonPropertyDescription("Quality gate status for this branch") @Nullable QualityGateStatus qualityGateStatus,
+    @JsonPropertyDescription("Date of the last analysis") @Nullable String analysisDate,
+    @JsonPropertyDescription("Internal branch identifier") String branchId
+  ) {
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/pullrequests/ListPullRequestsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/pullrequests/ListPullRequestsTool.java
@@ -37,9 +37,9 @@ public class ListPullRequestsTool extends Tool {
         .setName(TOOL_NAME)
         .setTitle("List SonarQube Pull Requests")
         .setDescription("List all pull requests for a project. " +
-          "Use this tool to discover available pull requests and their corresponding branch names before analyzing their coverage, issues, or quality. " +
+          "Use this tool to discover pull requests for PR-decorated analysis (coverage, issues, quality gate on new code). " +
           "Returns the pull request key/ID and source branch for each PR, which can be used with other tools that accept a pullRequest parameter. " +
-          "For long-lived branches (main, develop), use list_branches instead.")
+          "For branch-based analysis without pull requests, use list_branches instead.")
         .addProjectKeyProperty(PROJECT_KEY_PROPERTY, configuredProjectKey)
         .setReadOnlyHint()
         .build(),

--- a/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerGenericTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerGenericTest.java
@@ -470,6 +470,48 @@ class SonarQubeMcpServerGenericTest {
   }
 
   @SonarQubeMcpServerTest
+  void should_include_cloud_branch_instructions_on_sonarqube_cloud(SonarQubeMcpServerTestHarness harness) {
+    var environment = createStdioEnvironment(harness.getMockSonarQubeServer().baseUrl());
+    environment.put("SONARQUBE_ORG", "org");
+    harness.prepareMockWebServer(environment);
+
+    var server = new SonarQubeMcpServer(
+      new StdioServerTransportProvider(null),
+      null,
+      environment);
+    server.start();
+
+    assertThat(server.getMcpConfiguration().isSonarQubeCloud()).isTrue();
+    assertThat(server.getComposedInstructions())
+      .contains("SonarQube Cloud has three analysis contexts")
+      .contains("(SHORT)")
+      .contains("branchTypes=SHORT")
+      .doesNotContain("SonarQube Server has two analysis contexts");
+
+    server.shutdown();
+  }
+
+  @SonarQubeMcpServerTest
+  void should_include_server_branch_instructions_on_sonarqube_server(SonarQubeMcpServerTestHarness harness) {
+    var environment = createStdioEnvironment(harness.getMockSonarQubeServer().baseUrl());
+    harness.prepareMockWebServer(environment);
+
+    var server = new SonarQubeMcpServer(
+      new StdioServerTransportProvider(null),
+      null,
+      environment);
+    server.start();
+
+    assertThat(server.getMcpConfiguration().isSonarQubeCloud()).isFalse();
+    assertThat(server.getComposedInstructions())
+      .contains("SonarQube Server has two analysis contexts")
+      .doesNotContain("(SHORT)")
+      .doesNotContain("branchTypes");
+
+    server.shutdown();
+  }
+
+  @SonarQubeMcpServerTest
   void should_not_register_sara_tools_when_feature_flag_api_fails(SonarQubeMcpServerTestHarness harness) {
     var environment = createStdioEnvironment(harness.getMockSonarQubeServer().baseUrl());
     environment.put("SONARQUBE_ORG", "org");

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
@@ -33,8 +33,10 @@ import static org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpTestClient.asser
 
 class ListBranchesToolTests {
 
+  private static final Map<String, String> SONARQUBE_CLOUD_ENV = Map.of("SONARQUBE_ORG", "org");
+
   @SonarQubeMcpServerTest
-  void it_should_validate_output_schema_and_annotations(SonarQubeMcpServerTestHarness harness) {
+  void it_should_validate_server_output_schema_and_annotations(SonarQubeMcpServerTestHarness harness) {
     var mcpClient = harness.newClient();
 
     var tool = mcpClient.listTools().stream().filter(t -> t.name().equals(ListBranchesTool.TOOL_NAME)).findFirst().orElseThrow();
@@ -42,6 +44,79 @@ class ListBranchesToolTests {
     assertThat(tool.annotations()).isNotNull();
     assertThat(tool.annotations().readOnlyHint()).isTrue();
     assertThat(tool.annotations().openWorldHint()).isTrue();
+    @SuppressWarnings("unchecked")
+    var inputProperties = (Map<String, Object>) tool.inputSchema().get("properties");
+    assertThat(inputProperties).doesNotContainKey(ListBranchesTool.BRANCH_TYPES_PROPERTY);
+
+    assertSchemaEquals(tool.outputSchema(), """
+      {
+         "type":"object",
+         "properties":{
+            "projectKey":{
+               "description":"Project key",
+               "type":"string"
+            },
+            "totalBranches":{
+               "description":"Total number of branches",
+               "type":"integer"
+            },
+            "branches":{
+               "description":"List of branches for this project",
+               "type":"array",
+               "items":{
+                  "type":"object",
+                  "properties":{
+                     "name":{
+                        "type":"string",
+                        "description":"Branch name that can be used with other tools as the branch parameter"
+                     },
+                     "isMain":{
+                        "type":"boolean",
+                        "description":"Whether this is the main branch"
+                     },
+                     "qualityGateStatus":{
+                        "type":"string",
+                        "enum":["OK","ERROR","WARN","NONE"],
+                        "description":"Quality gate status for this branch"
+                     },
+                     "analysisDate":{
+                        "type":"string",
+                        "description":"Date of the last analysis"
+                     },
+                     "branchId":{
+                        "type":"string",
+                        "description":"Internal branch identifier"
+                     }
+                  },
+                  "required":[
+                     "branchId",
+                     "isMain",
+                     "name"
+                  ]
+               }
+            }
+         },
+         "required":[
+            "branches",
+            "projectKey",
+            "totalBranches"
+         ]
+      }
+      """);
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_validate_cloud_output_schema_and_annotations(SonarQubeMcpServerTestHarness harness) {
+    var mcpClient = harness.newClient(SONARQUBE_CLOUD_ENV);
+
+    var tool = mcpClient.listTools().stream().filter(t -> t.name().equals(ListBranchesTool.TOOL_NAME)).findFirst().orElseThrow();
+
+    assertThat(tool.annotations()).isNotNull();
+    assertThat(tool.annotations().readOnlyHint()).isTrue();
+    assertThat(tool.annotations().openWorldHint()).isTrue();
+    @SuppressWarnings("unchecked")
+    var inputProperties = (Map<String, Object>) tool.inputSchema().get("properties");
+    assertThat(inputProperties).containsKey(ListBranchesTool.BRANCH_TYPES_PROPERTY);
 
     assertSchemaEquals(tool.outputSchema(), """
       {
@@ -72,7 +147,7 @@ class ListBranchesToolTests {
                      "type":{
                         "type":"string",
                         "enum":["LONG","SHORT","BRANCH"],
-                        "description":"Branch type in SonarQube (LONG or SHORT on SonarQube Cloud, BRANCH on SonarQube Server)"
+                        "description":"Branch type: LONG for main/develop, SHORT for feature branches analyzed without pull requests"
                      },
                      "qualityGateStatus":{
                         "type":"string",
@@ -89,7 +164,7 @@ class ListBranchesToolTests {
                      },
                      "mergeBranch":{
                         "type":"string",
-                        "description":"Target branch for short-lived branches on SonarQube Cloud (e.g. main, master)"
+                        "description":"Target branch for short-lived branches (e.g. main, master)"
                      }
                   },
                   "required":[
@@ -141,7 +216,7 @@ class ListBranchesToolTests {
   }
 
   @SonarQubeMcpServerTest
-  void it_should_list_long_lived_branches_for_sonarqube_server(SonarQubeMcpServerTestHarness harness) {
+  void it_should_list_branches_for_sonarqube_server(SonarQubeMcpServerTestHarness harness) {
     harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
       .willReturn(aResponse().withResponseBody(
         Body.fromJsonBytes(generateSonarQubeServerBranchesResponse().getBytes(StandardCharsets.UTF_8))
@@ -157,14 +232,12 @@ class ListBranchesToolTests {
         "branches" : [ {
           "name" : "develop",
           "isMain" : false,
-          "type" : "BRANCH",
           "qualityGateStatus" : "OK",
           "analysisDate" : "2017-04-03T13:37:00+0100",
           "branchId" : "ac312cc6-26a2-4e2c-9eff-1072358f2017"
         }, {
           "name" : "main",
           "isMain" : true,
-          "type" : "BRANCH",
           "qualityGateStatus" : "ERROR",
           "analysisDate" : "2017-04-01T01:15:42+0100",
           "branchId" : "57f02458-65db-4e7f-a144-20122af12a4c"
@@ -180,7 +253,7 @@ class ListBranchesToolTests {
       .willReturn(aResponse().withResponseBody(
         Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
       )));
-    var mcpClient = harness.newClient();
+    var mcpClient = harness.newClient(SONARQUBE_CLOUD_ENV);
 
     var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
 
@@ -213,7 +286,7 @@ class ListBranchesToolTests {
       .willReturn(aResponse().withResponseBody(
         Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
       )));
-    var mcpClient = harness.newClient();
+    var mcpClient = harness.newClient(SONARQUBE_CLOUD_ENV);
 
     var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(
       ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project",
@@ -240,7 +313,7 @@ class ListBranchesToolTests {
       .willReturn(aResponse().withResponseBody(
         Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
       )));
-    var mcpClient = harness.newClient();
+    var mcpClient = harness.newClient(SONARQUBE_CLOUD_ENV);
 
     var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(
       ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project",

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
@@ -72,7 +72,7 @@ class ListBranchesToolTests {
                      "type":{
                         "type":"string",
                         "enum":["LONG","SHORT","BRANCH"],
-                        "description":"Branch type in SonarQube (LONG on SonarQube Cloud, BRANCH on SonarQube Server)"
+                        "description":"Branch type in SonarQube (LONG or SHORT on SonarQube Cloud, BRANCH on SonarQube Server)"
                      },
                      "qualityGateStatus":{
                         "type":"string",
@@ -86,6 +86,10 @@ class ListBranchesToolTests {
                      "branchId":{
                         "type":"string",
                         "description":"Internal branch identifier"
+                     },
+                     "mergeBranch":{
+                        "type":"string",
+                        "description":"Target branch for short-lived branches on SonarQube Cloud (e.g. main, master)"
                      }
                   },
                   "required":[
@@ -171,7 +175,7 @@ class ListBranchesToolTests {
   }
 
   @SonarQubeMcpServerTest
-  void it_should_filter_short_branches_on_sonarcloud(SonarQubeMcpServerTestHarness harness) {
+  void it_should_include_short_lived_branches_on_sonarcloud(SonarQubeMcpServerTestHarness harness) {
     harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
       .willReturn(aResponse().withResponseBody(
         Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
@@ -179,6 +183,41 @@ class ListBranchesToolTests {
     var mcpClient = harness.newClient();
 
     var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project"));
+
+    assertResultEquals(result, """
+      {
+        "projectKey" : "my_project",
+        "totalBranches" : 2,
+        "branches" : [ {
+          "name" : "feature/foo",
+          "isMain" : false,
+          "type" : "SHORT",
+          "qualityGateStatus" : "OK",
+          "analysisDate" : "2017-08-03T13:37:00+0100",
+          "branchId" : "93cb33a1-b3dd-4226-b0a0-1d74e4dec194",
+          "mergeBranch" : "master"
+        }, {
+          "name" : "master",
+          "isMain" : true,
+          "type" : "LONG",
+          "qualityGateStatus" : "ERROR",
+          "analysisDate" : "2017-04-01T01:15:42+0100",
+          "branchId" : "88471269-96e8-47f8-8c7d-e40e729f1373"
+        } ]
+      }""");
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_filter_long_lived_branches_on_sonarcloud(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withResponseBody(
+        Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
+      )));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(
+      ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project",
+      ListBranchesTool.BRANCH_TYPES_PROPERTY, "LONG"));
 
     assertResultEquals(result, """
       {
@@ -191,6 +230,34 @@ class ListBranchesToolTests {
           "qualityGateStatus" : "ERROR",
           "analysisDate" : "2017-04-01T01:15:42+0100",
           "branchId" : "88471269-96e8-47f8-8c7d-e40e729f1373"
+        } ]
+      }""");
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_filter_short_lived_branches_on_sonarcloud(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(ProjectBranchesApi.BRANCHES_LIST_PATH + "?project=my_project")
+      .willReturn(aResponse().withResponseBody(
+        Body.fromJsonBytes(generateSonarCloudBranchesResponse().getBytes(StandardCharsets.UTF_8))
+      )));
+    var mcpClient = harness.newClient();
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(
+      ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project",
+      ListBranchesTool.BRANCH_TYPES_PROPERTY, "SHORT"));
+
+    assertResultEquals(result, """
+      {
+        "projectKey" : "my_project",
+        "totalBranches" : 1,
+        "branches" : [ {
+          "name" : "feature/foo",
+          "isMain" : false,
+          "type" : "SHORT",
+          "qualityGateStatus" : "OK",
+          "analysisDate" : "2017-08-03T13:37:00+0100",
+          "branchId" : "93cb33a1-b3dd-4226-b0a0-1d74e4dec194",
+          "mergeBranch" : "master"
         } ]
       }""");
   }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesToolTests.java
@@ -19,6 +19,7 @@ package org.sonarsource.sonarqube.mcp.tools.branches;
 import io.modelcontextprotocol.spec.McpSchema;
 import com.github.tomakehurst.wiremock.http.Body;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import org.sonarsource.sonarqube.mcp.harness.ReceivedRequest;
 import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTest;
@@ -117,6 +118,9 @@ class ListBranchesToolTests {
     @SuppressWarnings("unchecked")
     var inputProperties = (Map<String, Object>) tool.inputSchema().get("properties");
     assertThat(inputProperties).containsKey(ListBranchesTool.BRANCH_TYPES_PROPERTY);
+    @SuppressWarnings("unchecked")
+    var branchTypesProperty = (Map<String, Object>) inputProperties.get(ListBranchesTool.BRANCH_TYPES_PROPERTY);
+    assertThat(branchTypesProperty).containsEntry("enum", List.of(BranchTypes.BRANCH_TYPES_FILTER_VALUES));
 
     assertSchemaEquals(tool.outputSchema(), """
       {
@@ -146,7 +150,7 @@ class ListBranchesToolTests {
                      },
                      "type":{
                         "type":"string",
-                        "enum":["LONG","SHORT","BRANCH"],
+                        "enum":["LONG","SHORT"],
                         "description":"Branch type: LONG for main/develop, SHORT for feature branches analyzed without pull requests"
                      },
                      "qualityGateStatus":{
@@ -333,6 +337,19 @@ class ListBranchesToolTests {
           "mergeBranch" : "master"
         } ]
       }""");
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_return_error_for_invalid_branch_types_on_sonarcloud(SonarQubeMcpServerTestHarness harness) {
+    var mcpClient = harness.newClient(SONARQUBE_CLOUD_ENV);
+
+    var result = mcpClient.callTool(ListBranchesTool.TOOL_NAME, Map.of(
+      ListBranchesTool.PROJECT_KEY_PROPERTY, "my_project",
+      ListBranchesTool.BRANCH_TYPES_PROPERTY, "INVALID"));
+
+    assertThat(result.isError()).isTrue();
+    assertThat(result.content().toString()).contains("input validation failed")
+      .contains("/branchTypes: does not have a value in the enumeration [\"ALL\", \"LONG\", \"SHORT\"]");
   }
 
   @SonarQubeMcpServerTest

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusToolTests.java
@@ -163,7 +163,7 @@ class ProjectStatusToolTests {
           ProjectStatusTool.PULL_REQUEST_PROPERTY, "5461"));
 
       assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true).addTextContent(
-        "Cannot use 'branch' and 'pullRequest' together. Use 'branch' for long-lived branches (see list_branches) or 'pullRequest' for pull requests (see list_pull_requests).").build());
+        "Cannot use 'branch' and 'pullRequest' together. Use 'branch' for branch-based analysis (see list_branches) or 'pullRequest' for pull request analysis (see list_pull_requests).").build());
     }
 
     @SonarQubeMcpServerTest


### PR DESCRIPTION
----
## Summary by Gitar

- **Tool Enhancements:**
  - Updated `list_branches` to support `short-lived` branches and added an optional `branchTypes` filter (`ALL`, `LONG`, `SHORT`).
  - Added `mergeBranch` field to `list_branches` output to identify target branches for short-lived branches.
- **Documentation & Context Updates:**
  - Updated `README.md` and `POWER.md` to clarify the distinction between branch-based analysis (long/short-lived) and pull request analysis.
  - Updated error messages and descriptions in `BranchPullRequestContext` and `ListPullRequestsTool` to reflect broader branch support.
- **Testing:**
  - Added comprehensive test cases in `ListBranchesToolTests` for filtering branch types and verifying `mergeBranch` output.


<sub>This will update automatically on new commits.</sub>