### PR TITLE
MCP-535 Add SBOM and max-mode provenance

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,6 +77,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
+          provenance: mode=max
           build-args: |
             MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
           tags: ${{ needs.prepare.outputs.temp_image }}
@@ -178,6 +180,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
+          provenance: mode=max
           build-args: |
             MCP_SERVER_VERSION=${{ needs.prepare.outputs.version }}
           tags: ${{ needs.prepare.outputs.tags }}


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Enabled SBOM generation and set provenance to `mode=max` in `docker-publish.yml` for container builds.

<sub>This will update automatically on new commits.</sub>