### PR TITLE
MCP-546 Validate plugin filename and verify hash

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizer.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
@@ -59,23 +60,37 @@ public class PluginsSynchronizer {
     }
     for (var serverPlugin : serverPlugins) {
       if (shouldDownload(serverPlugin)) {
-        downloadPlugin(serverPlugin.key(), pluginsPath.resolve(serverPlugin.filename()));
+        downloadPlugin(serverPlugin.key(), resolvePluginPath(serverPlugin.filename()), serverPlugin.hash());
       }
     }
   }
 
   private boolean shouldDownload(InstalledPluginsResponse.Plugin plugin) {
-    return plugin.sonarLintSupported() 
-        && SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(plugin.key())
-        && !Files.exists(pluginsPath.resolve(plugin.filename()));
+    if (!plugin.sonarLintSupported() || !SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(plugin.key())) {
+      return false;
+    }
+    var localPath = resolvePluginPath(plugin.filename());
+    if (!Files.exists(localPath)) {
+      return true;
+    }
+    var expectedHash = plugin.hash();
+    if (expectedHash == null || expectedHash.isBlank()) {
+      return true;
+    }
+    try {
+      return !expectedHash.equalsIgnoreCase(computeMd5Hex(localPath));
+    } catch (IOException e) {
+      return true;
+    }
   }
 
-  private void downloadPlugin(String pluginKey, Path localPath) {
+  private void downloadPlugin(String pluginKey, Path localPath, String expectedHash) {
     try (var response = serverApi.pluginsApi().downloadPlugin(pluginKey)) {
       if (response.isSuccessful()) {
         try (var inputStream = response.bodyAsStream()) {
           FileUtils.copyInputStreamToFile(inputStream, localPath.toFile());
         }
+        verifyDownloadedPluginHash(pluginKey, localPath, expectedHash);
         LOG.info("Successfully downloaded plugin '" + pluginKey + "' to " + localPath);
       } else {
         throw new IllegalStateException("Failed to download plugin '" + pluginKey + "': HTTP status " + response.code());
@@ -85,10 +100,52 @@ public class PluginsSynchronizer {
     }
   }
 
+  private static void verifyDownloadedPluginHash(String pluginKey, Path localPath, String expectedHash) {
+    try {
+      var actualHash = computeMd5Hex(localPath);
+      if (!expectedHash.equalsIgnoreCase(actualHash)) {
+        deletePluginFileQuietly(localPath);
+        throw new IllegalStateException("Plugin '" + pluginKey + "' hash mismatch: expected " + expectedHash + ", got " + actualHash);
+      }
+    } catch (IOException e) {
+      deletePluginFileQuietly(localPath);
+      throw new IllegalStateException("Failed to verify hash for plugin '" + pluginKey + "'", e);
+    }
+  }
+
+  private static void deletePluginFileQuietly(Path localPath) {
+    try {
+      Files.deleteIfExists(localPath);
+    } catch (IOException e) {
+      LOG.error("Failed to delete invalid plugin file: " + localPath, e);
+    }
+  }
+
+  private static String computeMd5Hex(Path localPath) throws IOException {
+    try (var inputStream = Files.newInputStream(localPath)) {
+      return DigestUtils.md5Hex(inputStream);
+    }
+  }
+
+  private Path resolvePluginPath(String filename) {
+    if (Path.of(filename).isAbsolute() || filename.indexOf('\\') >= 0) {
+      throw new IllegalStateException("Invalid plugin filename '" + filename + "': must be a simple file name");
+    }
+    var normalizedPluginsPath = pluginsPath.normalize();
+    var candidate = pluginsPath.resolve(filename).normalize();
+    if (!candidate.startsWith(normalizedPluginsPath)) {
+      throw new IllegalStateException("Invalid plugin filename '" + filename + "': resolves outside the plugins directory");
+    }
+    if (!filename.equals(candidate.getFileName().toString())) {
+      throw new IllegalStateException("Invalid plugin filename '" + filename + "': must be a simple file name");
+    }
+    return candidate;
+  }
+
   private void cleanupUnknownPlugins(List<InstalledPluginsResponse.Plugin> serverPlugins) {
     var supportedServerPlugins = serverPlugins.stream()
       .filter(plugin -> SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(plugin.key()))
-      .map(InstalledPluginsResponse.Plugin::filename)
+      .map(plugin -> resolvePluginPath(plugin.filename()).getFileName().toString())
       .collect(Collectors.toSet());
     try (var directoryStream = Files.newDirectoryStream(pluginsPath, "*.jar")) {
       for (var localFile : directoryStream) {
@@ -115,8 +172,11 @@ public class PluginsSynchronizer {
     var pluginsPaths = new HashSet<Path>();
     var enabledLanguages = EnumSet.noneOf(Language.class);
     for (var serverPlugin : serverPlugins) {
-      var pluginPath = pluginsPath.resolve(serverPlugin.filename());
-      if (serverPlugin.sonarLintSupported() && Files.exists(pluginPath)) {
+      if (!serverPlugin.sonarLintSupported() || !SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(serverPlugin.key())) {
+        continue;
+      }
+      var pluginPath = resolvePluginPath(serverPlugin.filename());
+      if (Files.exists(pluginPath)) {
         SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.forEach((supportedPluginKey, supportedLanguages) -> {
           if (serverPlugin.key().equals(supportedPluginKey)) {
             pluginsPaths.add(pluginPath);

--- a/src/main/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizer.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
@@ -59,8 +60,12 @@ public class PluginsSynchronizer {
       throw new IllegalStateException("Unable to create plugins directory", e);
     }
     for (var serverPlugin : serverPlugins) {
-      if (shouldDownload(serverPlugin)) {
-        downloadPlugin(serverPlugin.key(), resolvePluginPath(serverPlugin.filename()), serverPlugin.hash());
+      try {
+        if (shouldDownload(serverPlugin)) {
+          downloadPlugin(serverPlugin.key(), resolvePluginPath(serverPlugin.filename()), serverPlugin.hash());
+        }
+      } catch (RuntimeException e) {
+        LOG.error("Failed to download plugin '" + serverPlugin.key() + "'", e);
       }
     }
   }
@@ -145,7 +150,8 @@ public class PluginsSynchronizer {
   private void cleanupUnknownPlugins(List<InstalledPluginsResponse.Plugin> serverPlugins) {
     var supportedServerPlugins = serverPlugins.stream()
       .filter(plugin -> SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(plugin.key()))
-      .map(plugin -> resolvePluginPath(plugin.filename()).getFileName().toString())
+      .map(this::safePluginFilename)
+      .filter(Objects::nonNull)
       .collect(Collectors.toSet());
     try (var directoryStream = Files.newDirectoryStream(pluginsPath, "*.jar")) {
       for (var localFile : directoryStream) {
@@ -172,22 +178,30 @@ public class PluginsSynchronizer {
     var pluginsPaths = new HashSet<Path>();
     var enabledLanguages = EnumSet.noneOf(Language.class);
     for (var serverPlugin : serverPlugins) {
-      if (!serverPlugin.sonarLintSupported() || !SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(serverPlugin.key())) {
-        continue;
-      }
-      var pluginPath = resolvePluginPath(serverPlugin.filename());
-      if (Files.exists(pluginPath)) {
-        SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.forEach((supportedPluginKey, supportedLanguages) -> {
-          if (serverPlugin.key().equals(supportedPluginKey)) {
+      if (serverPlugin.sonarLintSupported() && SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.containsKey(serverPlugin.key())) {
+        try {
+          var pluginPath = resolvePluginPath(serverPlugin.filename());
+          if (Files.exists(pluginPath)) {
             pluginsPaths.add(pluginPath);
-            enabledLanguages.addAll(supportedLanguages);
+            enabledLanguages.addAll(SUPPORTED_LANGUAGES_BY_PLUGIN_KEY.get(serverPlugin.key()));
           }
-        });
+        } catch (RuntimeException e) {
+          LOG.error("Skipping plugin '" + serverPlugin.key() + "' due to invalid filename", e);
+        }
       }
     }
 
     LOG.info("Found " + pluginsPaths.size() + " plugins, enabled languages: " + enabledLanguages);
     return new BackendService.AnalyzersAndLanguagesEnabled(pluginsPaths, enabledLanguages);
+  }
+
+  private String safePluginFilename(InstalledPluginsResponse.Plugin plugin) {
+    try {
+      return resolvePluginPath(plugin.filename()).getFileName().toString();
+    } catch (RuntimeException e) {
+      LOG.error("Skipping plugin '" + plugin.key() + "' during cleanup due to invalid filename", e);
+      return null;
+    }
   }
 
 }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/plugins/response/InstalledPluginsResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/plugins/response/InstalledPluginsResponse.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public record InstalledPluginsResponse(List<Plugin> plugins) {
 
-  public record Plugin(String key, boolean sonarLintSupported, String filename) {
+  public record Plugin(String key, boolean sonarLintSupported, String filename, String hash) {
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/harness/SonarQubeMcpServerTestHarness.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/harness/SonarQubeMcpServerTestHarness.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -236,20 +237,25 @@ public class SonarQubeMcpServerTestHarness extends TypeBasedParameterResolver<So
     
     // Only set up plugin stubs if plugins are enabled for this test
     if (pluginsEnabled) {
-      mockSonarQubeServer.stubFor(get(PluginsApi.INSTALLED_PLUGINS_PATH).willReturn(okJson("""
-        {
-            "plugins": [
-              {
-                "key": "php",
-                "filename": "sonar-php-plugin-3.58.0.16263.jar",
-                "sonarLintSupported": true
-              }
-            ]
-          }
-        """)));
+      var pluginFilename = "sonar-php-plugin-3.58.0.16263.jar";
+      var pluginJarPath = Paths.get("build/sonarqube-mcp-server/plugins/" + pluginFilename);
       try {
+        var pluginBytes = Files.readAllBytes(pluginJarPath);
+        var pluginHash = DigestUtils.md5Hex(pluginBytes);
+        mockSonarQubeServer.stubFor(get(PluginsApi.INSTALLED_PLUGINS_PATH).willReturn(okJson("""
+          {
+              "plugins": [
+                {
+                  "key": "php",
+                  "filename": "%s",
+                  "hash": "%s",
+                  "sonarLintSupported": true
+                }
+              ]
+            }
+          """.formatted(pluginFilename, pluginHash))));
         mockSonarQubeServer.stubFor(get(PluginsApi.DOWNLOAD_PLUGINS_PATH + "?plugin=php")
-          .willReturn(aResponse().withBody(Files.readAllBytes(Paths.get("build/sonarqube-mcp-server/plugins/sonar-php-plugin-3.58.0.16263.jar")))));
+          .willReturn(aResponse().withBody(pluginBytes)));
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizerTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizerTest.java
@@ -30,7 +30,6 @@ import org.sonarsource.sonarqube.mcp.serverapi.plugins.PluginsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.plugins.response.InstalledPluginsResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -117,7 +116,7 @@ class PluginsSynchronizerTest {
   }
 
   @Test
-  void it_should_throw_if_plugin_download_request_is_not_successful(@TempDir Path tempDir) {
+  void it_should_continue_when_plugin_download_request_is_not_successful(@TempDir Path tempDir) {
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
@@ -129,10 +128,10 @@ class PluginsSynchronizerTest {
     when(pluginsApi.downloadPlugin("java")).thenReturn(response);
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
-    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+    var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
 
-    assertThat(throwable).isInstanceOf(IllegalStateException.class)
-        .hasMessage("Failed to download plugin 'java': HTTP status 500");
+    assertThat(analyzers.analyzerPaths()).isEmpty();
+    assertThat(analyzers.enabledLanguages()).isEmpty();
   }
 
   @Test
@@ -180,7 +179,7 @@ class PluginsSynchronizerTest {
   }
 
   @Test
-  void it_should_reject_absolute_plugin_filename(@TempDir Path tempDir) {
+  void it_should_skip_plugin_with_absolute_filename(@TempDir Path tempDir) {
     var escapePath = tempDir.resolve("pwned.jar");
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
@@ -189,16 +188,15 @@ class PluginsSynchronizerTest {
       new InstalledPluginsResponse.Plugin("java", true, escapePath.toString(), HELLO_MD5))));
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
-    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+    var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
 
-    assertThat(throwable).isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("Invalid plugin filename");
+    assertThat(analyzers.analyzerPaths()).isEmpty();
     assertThat(escapePath).doesNotExist();
     verify(pluginsApi, never()).downloadPlugin("java");
   }
 
   @Test
-  void it_should_reject_traversal_plugin_filename(@TempDir Path tempDir) {
+  void it_should_skip_plugin_with_traversal_filename(@TempDir Path tempDir) {
     var escapePath = tempDir.resolve("pwned.jar");
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
@@ -207,16 +205,15 @@ class PluginsSynchronizerTest {
       new InstalledPluginsResponse.Plugin("java", true, "../../pwned.jar", HELLO_MD5))));
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
-    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+    var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
 
-    assertThat(throwable).isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("Invalid plugin filename");
+    assertThat(analyzers.analyzerPaths()).isEmpty();
     assertThat(escapePath).doesNotExist();
     verify(pluginsApi, never()).downloadPlugin("java");
   }
 
   @Test
-  void it_should_throw_if_downloaded_plugin_hash_does_not_match(@TempDir Path tempDir) {
+  void it_should_skip_plugin_when_downloaded_hash_does_not_match(@TempDir Path tempDir) {
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
@@ -228,11 +225,35 @@ class PluginsSynchronizerTest {
     when(pluginsApi.downloadPlugin("java")).thenReturn(response);
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
-    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+    var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
 
-    assertThat(throwable).isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("hash mismatch");
+    assertThat(analyzers.analyzerPaths()).isEmpty();
     assertThat(tempDir.resolve("plugins").resolve("filename")).doesNotExist();
+  }
+
+  @Test
+  void it_should_continue_with_other_plugins_when_one_download_fails(@TempDir Path tempDir) {
+    var serverApi = mock(ServerApi.class);
+    var pluginsApi = mock(PluginsApi.class);
+    when(serverApi.pluginsApi()).thenReturn(pluginsApi);
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, "java-plugin.jar", HELLO_MD5),
+      new InstalledPluginsResponse.Plugin("python", true, "python-plugin.jar", HELLO_MD5))));
+    var failedResponse = mock(HttpClient.Response.class);
+    when(failedResponse.isSuccessful()).thenReturn(false);
+    when(failedResponse.code()).thenReturn(500);
+    var successResponse = mock(HttpClient.Response.class);
+    when(successResponse.isSuccessful()).thenReturn(true);
+    when(successResponse.bodyAsStream()).thenReturn(new ByteArrayInputStream(HELLO_CONTENT.getBytes()));
+    when(pluginsApi.downloadPlugin("java")).thenReturn(failedResponse);
+    when(pluginsApi.downloadPlugin("python")).thenReturn(successResponse);
+    var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
+
+    var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
+
+    assertThat(analyzers.analyzerPaths()).containsExactly(tempDir.resolve("plugins").resolve("python-plugin.jar"));
+    assertThat(analyzers.enabledLanguages()).containsExactlyInAnyOrder(Language.PYTHON, Language.IPYTHON);
+    assertThat(tempDir.resolve("plugins").resolve("java-plugin.jar")).doesNotExist();
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizerTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/plugins/PluginsSynchronizerTest.java
@@ -32,18 +32,25 @@ import org.sonarsource.sonarqube.mcp.serverapi.plugins.response.InstalledPlugins
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PluginsSynchronizerTest {
+
+  private static final String HELLO_CONTENT = "hello";
+  private static final String HELLO_MD5 = "5d41402abc4b2a76b9719d911017c592";
+
   @Test
   void it_should_download_sonarlint_supported_plugins(@TempDir Path tempDir) {
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
-    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(new InstalledPluginsResponse.Plugin("java", true, "filename"))));
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, "filename", HELLO_MD5))));
     var response = mock(HttpClient.Response.class);
     when(response.isSuccessful()).thenReturn(true);
-    when(response.bodyAsStream()).thenReturn(new ByteArrayInputStream("hello".getBytes()));
+    when(response.bodyAsStream()).thenReturn(new ByteArrayInputStream(HELLO_CONTENT.getBytes()));
     when(pluginsApi.downloadPlugin("java")).thenReturn(response);
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
@@ -54,7 +61,7 @@ class PluginsSynchronizerTest {
     assertThat(analyzers.enabledLanguages()).containsExactly(Language.JAVA);
     assertThat(pluginPath)
       .exists()
-      .hasContent("hello");
+      .hasContent(HELLO_CONTENT);
   }
 
   @Test
@@ -62,7 +69,8 @@ class PluginsSynchronizerTest {
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
-    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(new InstalledPluginsResponse.Plugin("key", false, "filename"))));
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("key", false, "filename", HELLO_MD5))));
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
     var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
@@ -75,7 +83,8 @@ class PluginsSynchronizerTest {
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
-    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(new InstalledPluginsResponse.Plugin("cobol", true, "sonar-cobol-plugin.jar"))));
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("cobol", true, "sonar-cobol-plugin.jar", HELLO_MD5))));
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
     var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
@@ -90,11 +99,12 @@ class PluginsSynchronizerTest {
     var pluginsFolderPath = tempDir.resolve("plugins");
     Files.createDirectories(pluginsFolderPath);
     var pluginPath = pluginsFolderPath.resolve("filename");
-    Files.writeString(pluginPath, "hello");
+    Files.writeString(pluginPath, HELLO_CONTENT);
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
-    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(new InstalledPluginsResponse.Plugin("java", true, "filename"))));
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, "filename", HELLO_MD5))));
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
     var analyzers = pluginsSynchronizer.synchronizeAnalyzers();
@@ -102,7 +112,8 @@ class PluginsSynchronizerTest {
     assertThat(analyzers.analyzerPaths()).containsExactly(pluginPath);
     assertThat(pluginPath)
       .exists()
-      .hasContent("hello");
+      .hasContent(HELLO_CONTENT);
+    verify(pluginsApi, never()).downloadPlugin("java");
   }
 
   @Test
@@ -110,7 +121,8 @@ class PluginsSynchronizerTest {
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
-    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(new InstalledPluginsResponse.Plugin("java", true, "filename"))));
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, "filename", HELLO_MD5))));
     var response = mock(HttpClient.Response.class);
     when(response.isSuccessful()).thenReturn(false);
     when(response.code()).thenReturn(500);
@@ -128,7 +140,7 @@ class PluginsSynchronizerTest {
     var pluginsFolderPath = tempDir.resolve("plugins");
     Files.createDirectories(pluginsFolderPath);
     var pluginPath = pluginsFolderPath.resolve("plugin.jar");
-    Files.writeString(pluginPath, "hello");
+    Files.writeString(pluginPath, HELLO_CONTENT);
     var serverApi = mock(ServerApi.class);
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
@@ -156,7 +168,7 @@ class PluginsSynchronizerTest {
     var pluginsApi = mock(PluginsApi.class);
     when(serverApi.pluginsApi()).thenReturn(pluginsApi);
     when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
-      new InstalledPluginsResponse.Plugin("cobol", true, "sonar-cobol-plugin.jar")
+      new InstalledPluginsResponse.Plugin("cobol", true, "sonar-cobol-plugin.jar", HELLO_MD5)
     )));
     var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
 
@@ -165,6 +177,62 @@ class PluginsSynchronizerTest {
     assertThat(analyzers.analyzerPaths()).isEmpty();
     assertThat(analyzers.enabledLanguages()).isEmpty();
     assertThat(unsupportedPluginPath).doesNotExist();
+  }
+
+  @Test
+  void it_should_reject_absolute_plugin_filename(@TempDir Path tempDir) {
+    var escapePath = tempDir.resolve("pwned.jar");
+    var serverApi = mock(ServerApi.class);
+    var pluginsApi = mock(PluginsApi.class);
+    when(serverApi.pluginsApi()).thenReturn(pluginsApi);
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, escapePath.toString(), HELLO_MD5))));
+    var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
+
+    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+
+    assertThat(throwable).isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Invalid plugin filename");
+    assertThat(escapePath).doesNotExist();
+    verify(pluginsApi, never()).downloadPlugin("java");
+  }
+
+  @Test
+  void it_should_reject_traversal_plugin_filename(@TempDir Path tempDir) {
+    var escapePath = tempDir.resolve("pwned.jar");
+    var serverApi = mock(ServerApi.class);
+    var pluginsApi = mock(PluginsApi.class);
+    when(serverApi.pluginsApi()).thenReturn(pluginsApi);
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, "../../pwned.jar", HELLO_MD5))));
+    var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
+
+    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+
+    assertThat(throwable).isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Invalid plugin filename");
+    assertThat(escapePath).doesNotExist();
+    verify(pluginsApi, never()).downloadPlugin("java");
+  }
+
+  @Test
+  void it_should_throw_if_downloaded_plugin_hash_does_not_match(@TempDir Path tempDir) {
+    var serverApi = mock(ServerApi.class);
+    var pluginsApi = mock(PluginsApi.class);
+    when(serverApi.pluginsApi()).thenReturn(pluginsApi);
+    when(pluginsApi.getInstalled()).thenReturn(new InstalledPluginsResponse(List.of(
+      new InstalledPluginsResponse.Plugin("java", true, "filename", "00000000000000000000000000000000"))));
+    var response = mock(HttpClient.Response.class);
+    when(response.isSuccessful()).thenReturn(true);
+    when(response.bodyAsStream()).thenReturn(new ByteArrayInputStream(HELLO_CONTENT.getBytes()));
+    when(pluginsApi.downloadPlugin("java")).thenReturn(response);
+    var pluginsSynchronizer = new PluginsSynchronizer(serverApi, tempDir);
+
+    var throwable = catchThrowable(pluginsSynchronizer::synchronizeAnalyzers);
+
+    assertThat(throwable).isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("hash mismatch");
+    assertThat(tempDir.resolve("plugins").resolve("filename")).doesNotExist();
   }
 
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Security hardening:**
  - Added path validation in `resolvePluginPath` to prevent directory traversal and absolute path injection.
- **Plugin verification:**
  - Implemented MD5 hash verification for downloaded plugins to ensure integrity.
  - Enhanced `shouldDownload` to re-verify existing local plugin hashes before skipping downloads.
- **Data model updates:**
  - Included `hash` field in `InstalledPluginsResponse.Plugin` to support integrity checks during synchronization.

<sub>This will update automatically on new commits.</sub>