### PR TITLE
MCP-462 Make parameters consistent across tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,7 +930,7 @@ SOCKS5 proxies are supported.
 
 - **run_advanced_code_analysis** - Run advanced code analysis on SonarQube Cloud for a single file. Organization is inferred from MCP configuration.
     - `projectKey` - The key of the project - _Required String_ _(Ignored when `SONARQUBE_PROJECT_KEY` is defined)_
-    - `branchName` - Branch name used to retrieve the latest analysis context - _Required String_
+    - `branch` - Branch name used to retrieve the latest analysis context - _Required String_
     - `filePath` - Project-relative path of the file to analyze (e.g., `src/main/java/MyClass.java`). - _Required String_
     - `fileScope` - Defines in which scope the file originates from: 'MAIN' or 'TEST' (default: MAIN) - _String_
 
@@ -978,15 +978,15 @@ SOCKS5 proxies are supported.
 
 
 - **search_sonar_issues_in_projects** - Search for SonarQube issues in my organization's projects.
-  - `projects` - Optional list of Sonar projects - _String[]_
+  - `projectKeys` - Optional list of SonarQube project keys - _String[]_
   - `branch` - Optional long-lived branch name (e.g. main, develop). Use `list_branches` to discover valid names - _String_
   - `pullRequest` - Optional pull request key/ID. Use `list_pull_requests` to discover valid keys - _String_
   - `severities` - Optional list of severities to filter by. Possible values: INFO, LOW, MEDIUM, HIGH, BLOCKER - _String[]_
   - `impactSoftwareQualities` - Optional list of software qualities to filter by. Possible values: MAINTAINABILITY, RELIABILITY, SECURITY - _String[]_
   - `issueStatuses` - Optional list of issue statuses to filter by. Possible values: OPEN, CONFIRMED, FALSE_POSITIVE, ACCEPTED, FIXED, IN_SANDBOX - _String[]_
   - `issueKey` - Optional issue key to fetch a specific issue - _String_
-  - `p` - Optional page number (default: 1) - _Integer_
-  - `ps` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
+  - `pageIndex` - Optional 1-based page index (default: 1) - _Integer_
+  - `pageSize` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
 
 ### Security Hotspots
 
@@ -1000,8 +1000,8 @@ SOCKS5 proxies are supported.
   - `resolution` - Optional resolution filter: FIXED, SAFE, ACKNOWLEDGED - _String_
   - `sinceLeakPeriod` - Filter hotspots created since the leak period (new code) - _Boolean_
   - `onlyMine` - Show only hotspots assigned to me - _Boolean_
-  - `p` - Optional page number (default: 1) - _Integer_
-  - `ps` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
+  - `pageIndex` - Optional 1-based page index (default: 1) - _Integer_
+  - `pageSize` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
 
 
 - **show_security_hotspot** - Get detailed information about a specific Security Hotspot, including rule details, code context, flows, and comments.
@@ -1030,8 +1030,8 @@ SOCKS5 proxies are supported.
 ### Metrics
 
 - **search_metrics** - Search for SonarQube metrics.
-  - `p` - Optional page number (default: 1) - _Integer_
-  - `ps` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
+  - `pageIndex` - Optional 1-based page index (default: 1) - _Integer_
+  - `pageSize` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 100) - _Integer_
 
 ### Portfolios
 
@@ -1054,7 +1054,9 @@ SOCKS5 proxies are supported.
 ### Projects
 
 - **search_my_sonarqube_projects** - Find SonarQube projects. The response is paginated.
-  - `page` - Optional page number - _String_
+  - `pageIndex` - Optional 1-based page index (default: 1) - _Integer_
+  - `pageSize` - Optional page size. Must be greater than 0 and less than or equal to 500 (default: 500) - _Integer_
+  - `q` - Optional search query to filter projects by name (partial match) or key (exact match) - _String_
 
 
 - **list_branches** - List long-lived branches for a project (e.g. main, develop, master). Returns only `LONG` branches on SonarQube Cloud and `BRANCH` entries on SonarQube Server — names safe for the `branch` parameter on other tools. For pull requests, use `list_pull_requests` instead.

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
@@ -210,18 +210,10 @@ public abstract class Tool {
     @Nullable
     public List<String> getOptionalStringList(String argumentName) {
       var arg = argumentsMap.get(argumentName);
-      if (arg == null) {
+      if (!(arg instanceof List<?> list)) {
         return null;
       }
-      List<?> valuesSource = switch (arg) {
-        case List<?> list -> list;
-        case Object[] array -> List.of(array);
-        default -> null;
-      };
-      if (valuesSource == null) {
-        return null;
-      }
-      var values = valuesSource.stream()
+      var values = list.stream()
         .filter(Objects::nonNull)
         .map(String::valueOf)
         .filter(value -> !value.isBlank())

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
@@ -171,6 +171,26 @@ public abstract class Tool {
       return null;
     }
 
+    @Nullable
+    public Integer getOptionalPageIndex() {
+      return getOptionalInteger(ToolParameters.PAGE_INDEX);
+    }
+
+    @Nullable
+    public Integer getOptionalPageSize() {
+      return getOptionalInteger(ToolParameters.PAGE_SIZE);
+    }
+
+    public int getPageIndexOrDefault(int defaultValue) {
+      var pageIndex = getOptionalPageIndex();
+      return pageIndex != null ? pageIndex : defaultValue;
+    }
+
+    public int getPageSizeOrDefault(int defaultValue) {
+      var pageSize = getOptionalPageSize();
+      return pageSize != null ? pageSize : defaultValue;
+    }
+
     public int getIntOrDefault(String argumentName, int defaultValue) {
       var intArgument = getOptionalInteger(argumentName);
       if (intArgument == null) {
@@ -190,10 +210,18 @@ public abstract class Tool {
     @Nullable
     public List<String> getOptionalStringList(String argumentName) {
       var arg = argumentsMap.get(argumentName);
-      if (!(arg instanceof List<?> list)) {
+      if (arg == null) {
         return null;
       }
-      var values = list.stream()
+      List<?> valuesSource = switch (arg) {
+        case List<?> list -> list;
+        case Object[] array -> List.of(array);
+        default -> null;
+      };
+      if (valuesSource == null) {
+        return null;
+      }
+      var values = valuesSource.stream()
         .filter(Objects::nonNull)
         .map(String::valueOf)
         .filter(value -> !value.isBlank())

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/ToolParameters.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/ToolParameters.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.tools;
+
+/**
+ * Canonical MCP tool parameter names shared across all tools.
+ */
+public final class ToolParameters {
+
+  public static final String PROJECT_KEY = "projectKey";
+  public static final String PROJECT_KEYS = "projectKeys";
+  public static final String PAGE_INDEX = "pageIndex";
+  public static final String PAGE_SIZE = "pageSize";
+
+  private ToolParameters() {
+    // utility class
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/agenticreadiness/ListAgenticReadinessAssessmentsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/agenticreadiness/ListAgenticReadinessAssessmentsTool.java
@@ -20,18 +20,20 @@ import java.util.List;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.agenticreadiness.AgenticReadinessApi;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class ListAgenticReadinessAssessmentsTool extends Tool {
 
   public static final String TOOL_NAME = "list_agentic_readiness_assessments";
 
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String BRANCH_PROPERTY = "branch";
-  public static final String PAGE_INDEX_PROPERTY = "pageIndex";
-  public static final String PAGE_SIZE_PROPERTY = "pageSize";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
 
   static final int MAX_PAGE_SIZE = 100;
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/agenticreadiness/StartAgenticReadinessAssessmentTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/agenticreadiness/StartAgenticReadinessAssessmentTool.java
@@ -19,16 +19,18 @@ package org.sonarsource.sonarqube.mcp.tools.agenticreadiness;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.agenticreadiness.AgenticReadinessApi;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class StartAgenticReadinessAssessmentTool extends Tool {
 
   public static final String TOOL_NAME = "start_agentic_readiness_assessment";
 
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String BRANCH_PROPERTY = "branch";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;
   private final String configuredProjectKey;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
@@ -38,6 +38,7 @@ import org.sonarsource.sonarqube.mcp.slcore.BackendService;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 import static java.util.stream.Collectors.toMap;
 import static org.sonarsource.sonarqube.mcp.analysis.LanguageUtils.getSonarLanguageFromInput;
@@ -56,7 +57,7 @@ public class AnalyzeCodeSnippetTool extends Tool {
   }
 
   public static final String TOOL_NAME = "analyze_code_snippet";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String FILE_PATH_PROPERTY = "filePath";
   public static final String FILE_CONTENT_PROPERTY = "fileContent";
   public static final String SNIPPET_PROPERTY = "codeSnippet";

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
@@ -26,9 +26,11 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApi;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.a3s.request.AnalysisCreationRequest;
 import org.sonarsource.sonarqube.mcp.serverapi.a3s.response.AnalysisResponse;
+import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class RunAdvancedCodeAnalysisTool extends Tool {
 
@@ -36,8 +38,8 @@ public class RunAdvancedCodeAnalysisTool extends Tool {
 
   public static final String TOOL_NAME = "run_advanced_code_analysis";
 
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
-  public static final String BRANCH_NAME_PROPERTY = "branchName";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
+  public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String FILE_PATH_PROPERTY = "filePath";
   public static final String FILE_CONTENT_PROPERTY = "fileContent";
   public static final String FILE_SCOPE_PROPERTY = "fileScope";
@@ -64,7 +66,7 @@ public class RunAdvancedCodeAnalysisTool extends Tool {
         "Identifies code quality and security issues, leveraging the project's full analysis context for deeper cross-file detection. " +
         "Always specify the file scope (MAIN or TEST) for more accurate results.")
       .addProjectKeyProperty(PROJECT_KEY_PROPERTY, configuredProjectKey)
-      .addRequiredStringProperty(BRANCH_NAME_PROPERTY, "The branch name used to retrieve the latest analysis context from SonarQube Cloud.")
+      .addRequiredStringProperty(BRANCH_PROPERTY, "The branch name used to retrieve the latest analysis context from SonarQube Cloud.")
       .addRequiredStringProperty(FILE_PATH_PROPERTY, "Project-relative path of the file to analyze (e.g., 'src/main/java/MyClass.java').");
 
     return builder
@@ -118,7 +120,7 @@ public class RunAdvancedCodeAnalysisTool extends Tool {
     return new AnalysisCreationRequest(
       organizationKey,
       arguments.getProjectKeyWithFallback(PROJECT_KEY_PROPERTY, configuredProjectKey),
-      arguments.getStringOrThrow(BRANCH_NAME_PROPERTY),
+      arguments.getStringOrThrow(BRANCH_PROPERTY),
       arguments.getStringOrThrow(FILE_PATH_PROPERTY),
       fileContent,
       scope

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/branches/ListBranchesTool.java
@@ -21,6 +21,7 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.isLongLivedBranchType;
 import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseBranchType;
@@ -29,7 +30,7 @@ import static org.sonarsource.sonarqube.mcp.tools.branches.BranchTypes.parseQual
 public class ListBranchesTool extends Tool {
 
   public static final String TOOL_NAME = "list_branches";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
 
   private final ServerApiProvider serverApiProvider;
   @Nullable

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/dependencyrisks/SearchDependencyRisksTool.java
@@ -25,15 +25,16 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchDependencyRisksTool extends Tool {
 
   public static final String TOOL_NAME = "search_dependency_risks";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
-  public static final String PAGE_INDEX_PROPERTY = "pageIndex";
-  public static final String PAGE_SIZE_PROPERTY = "pageSize";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
 
   private final ServerApiProvider serverApiProvider;
   private final SonarQubeVersionChecker sonarQubeVersionChecker;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/SearchDuplicatedFilesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/duplications/SearchDuplicatedFilesTool.java
@@ -27,15 +27,16 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchDuplicatedFilesTool extends Tool {
 
   public static final String TOOL_NAME = "search_duplicated_files";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
-  public static final String PAGE_SIZE_PROPERTY = "pageSize";
-  public static final String PAGE_INDEX_PROPERTY = "pageIndex";
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
 
   private static final String DUPLICATED_LINES_METRIC = "duplicated_lines";
   private static final String DUPLICATED_BLOCKS_METRIC = "duplicated_blocks";

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsTool.java
@@ -24,12 +24,13 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchSecurityHotspotsTool extends Tool {
 
   public static final String TOOL_NAME = "search_security_hotspots";
 
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String HOTSPOT_KEYS_PROPERTY = "hotspotKeys";
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
@@ -38,8 +39,8 @@ public class SearchSecurityHotspotsTool extends Tool {
   public static final String RESOLUTION_PROPERTY = "resolution";
   public static final String SINCE_LEAK_PERIOD_PROPERTY = "sinceLeakPeriod";
   public static final String ONLY_MINE_PROPERTY = "onlyMine";
-  public static final String PAGE_PROPERTY = "p";
-  public static final String PAGE_SIZE_PROPERTY = "ps";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
   
   private static final String[] VALID_STATUSES = {"TO_REVIEW", "REVIEWED"};
   private static final String[] VALID_RESOLUTIONS = {"FIXED", "SAFE", "ACKNOWLEDGED"};
@@ -59,7 +60,7 @@ public class SearchSecurityHotspotsTool extends Tool {
       .addEnumProperty(RESOLUTION_PROPERTY, VALID_RESOLUTIONS, "Filter by resolution (when status is REVIEWED)")
       .addBooleanProperty(SINCE_LEAK_PERIOD_PROPERTY, "If true, only Security Hotspots created since the leak period (new code period) are returned")
       .addBooleanProperty(ONLY_MINE_PROPERTY, "If true, only Security Hotspots assigned to the current user are returned")
-      .addNumberProperty(PAGE_PROPERTY, "An optional page number. Defaults to 1.")
+      .addNumberProperty(PAGE_INDEX_PROPERTY, "An optional 1-based page index. Defaults to 1.")
       .addNumberProperty(PAGE_SIZE_PROPERTY, "An optional page size. Must be greater than 0 and less than or equal to 500. Defaults to 100.")
       .setReadOnlyHint()
       .build(),
@@ -112,8 +113,8 @@ public class SearchSecurityHotspotsTool extends Tool {
       arguments.getOptionalEnumValue(RESOLUTION_PROPERTY, VALID_RESOLUTIONS),
       arguments.getOptionalBoolean(SINCE_LEAK_PERIOD_PROPERTY),
       arguments.getOptionalBoolean(ONLY_MINE_PROPERTY),
-      arguments.getOptionalInteger(PAGE_PROPERTY),
-      arguments.getOptionalInteger(PAGE_SIZE_PROPERTY)
+      arguments.getOptionalPageIndex(),
+      arguments.getOptionalPageSize()
     );
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesTool.java
@@ -24,12 +24,13 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchIssuesTool extends Tool {
 
   public static final String TOOL_NAME = "search_sonar_issues_in_projects";
 
-  public static final String PROJECTS_PROPERTY = "projects";
+  public static final String PROJECT_KEYS_PROPERTY = ToolParameters.PROJECT_KEYS;
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String FILES_PROPERTY = "files";
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
@@ -37,8 +38,8 @@ public class SearchIssuesTool extends Tool {
   public static final String IMPACT_SOFTWARE_QUALITIES_PROPERTY = "impactSoftwareQualities";
   public static final String ISSUE_STATUSES_PROPERTY = "issueStatuses";
   public static final String ISSUE_KEY_PROPERTY = "issueKey";
-  public static final String PAGE_PROPERTY = "p";
-  public static final String PAGE_SIZE_PROPERTY = "ps";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
   
   private static final String[] VALID_SEVERITIES = {"INFO", "LOW", "MEDIUM", "HIGH", "BLOCKER"};
   private static final String[] VALID_IMPACT_SOFTWARE_QUALITIES = {"MAINTAINABILITY", "RELIABILITY", "SECURITY"};
@@ -61,14 +62,14 @@ public class SearchIssuesTool extends Tool {
       .setName(TOOL_NAME)
       .setTitle("Search SonarQube Issues")
       .setDescription(description)
-      .addArrayProperty(PROJECTS_PROPERTY, "string", "An optional list of Sonar projects to look in")
+      .addArrayProperty(PROJECT_KEYS_PROPERTY, "string", "An optional list of SonarQube project keys to look in")
       .addArrayProperty(FILES_PROPERTY, "string", "An optional list of component keys (files, directories, modules) to filter issues")
       .addBranchAndPullRequestProperties()
       .addEnumArrayProperty(SEVERITIES_PROPERTY, VALID_SEVERITIES, "An optional list of severities to filter by")
       .addEnumArrayProperty(IMPACT_SOFTWARE_QUALITIES_PROPERTY, VALID_IMPACT_SOFTWARE_QUALITIES, "An optional list of software qualities to filter by")
       .addEnumArrayProperty(ISSUE_STATUSES_PROPERTY, VALID_ISSUE_STATUSES, "An optional list of issue statuses to filter by. Note: IN_SANDBOX is valid only for SonarQube Server")
       .addArrayProperty(ISSUE_KEY_PROPERTY, "string", "An optional list of issue keys to fetch specific issues")
-      .addNumberProperty(PAGE_PROPERTY, "An optional page number. Defaults to 1.")
+      .addNumberProperty(PAGE_INDEX_PROPERTY, "An optional 1-based page index. Defaults to 1.")
       .addNumberProperty(PAGE_SIZE_PROPERTY, "An optional page size. Must be greater than 0 and less than or equal to 500. Defaults to 100.")
       .setReadOnlyHint()
       .build();
@@ -90,7 +91,7 @@ public class SearchIssuesTool extends Tool {
 
   private static IssuesApi.SearchParams extractSearchParams(Tool.Arguments arguments, BranchPullRequestContext.Params branchPullRequest) {
     return new IssuesApi.SearchParams(
-      arguments.getOptionalStringList(PROJECTS_PROPERTY),
+      arguments.getOptionalStringList(PROJECT_KEYS_PROPERTY),
       branchPullRequest.branch(),
       arguments.getOptionalStringList(FILES_PROPERTY),
       branchPullRequest.pullRequest(),
@@ -98,8 +99,8 @@ public class SearchIssuesTool extends Tool {
       arguments.getOptionalEnumList(IMPACT_SOFTWARE_QUALITIES_PROPERTY, VALID_IMPACT_SOFTWARE_QUALITIES),
       arguments.getOptionalEnumList(ISSUE_STATUSES_PROPERTY, VALID_ISSUE_STATUSES),
       arguments.getOptionalStringList(ISSUE_KEY_PROPERTY),
-      arguments.getOptionalInteger(PAGE_PROPERTY),
-      arguments.getOptionalInteger(PAGE_SIZE_PROPERTY)
+      arguments.getOptionalPageIndex(),
+      arguments.getOptionalPageSize()
     );
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
@@ -24,11 +24,12 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class GetComponentMeasuresTool extends Tool {
 
   public static final String TOOL_NAME = "get_component_measures";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String METRIC_KEYS_PROPERTY = "metricKeys";
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/SearchFilesByCoverageTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/SearchFilesByCoverageTool.java
@@ -28,16 +28,17 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchFilesByCoverageTool extends Tool {
 
   public static final String TOOL_NAME = "search_files_by_coverage";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
   public static final String MAX_COVERAGE_PROPERTY = "maxCoverage";
-  public static final String PAGE_INDEX_PROPERTY = "pageIndex";
-  public static final String PAGE_SIZE_PROPERTY = "pageSize";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
 
   // Metric keys
   private static final String METRIC_COVERAGE = "coverage";

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/metrics/SearchMetricsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/metrics/SearchMetricsTool.java
@@ -21,12 +21,13 @@ import org.sonarsource.sonarqube.mcp.serverapi.metrics.response.SearchMetricsRes
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchMetricsTool extends Tool {
 
   public static final String TOOL_NAME = "search_metrics";
-  public static final String PAGE_PROPERTY = "p";
-  public static final String PAGE_SIZE_PROPERTY = "ps";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
 
   private final ServerApiProvider serverApiProvider;
 
@@ -35,7 +36,7 @@ public class SearchMetricsTool extends Tool {
       .setName(TOOL_NAME)
       .setTitle("Search SonarQube Metrics")
       .setDescription("Search for available metrics")
-      .addNumberProperty(PAGE_PROPERTY, "1-based page number (default: 1)")
+      .addNumberProperty(PAGE_INDEX_PROPERTY, "1-based page index (default: 1)")
       .addNumberProperty(PAGE_SIZE_PROPERTY, "Page size. Must be greater than 0 and less than or equal to 500 (default: 100)")
       .setReadOnlyHint()
       .build(),
@@ -45,8 +46,8 @@ public class SearchMetricsTool extends Tool {
 
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
-    var page = arguments.getOptionalInteger(PAGE_PROPERTY);
-    var pageSize = arguments.getOptionalInteger(PAGE_SIZE_PROPERTY);
+    var page = arguments.getOptionalPageIndex();
+    var pageSize = arguments.getOptionalPageSize();
     
     var response = serverApiProvider.get().metricsApi().searchMetrics(page, pageSize);
     var toolResponse = buildStructuredContent(response);

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/portfolios/ListPortfoliosTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/portfolios/ListPortfoliosTool.java
@@ -24,6 +24,7 @@ import org.sonarsource.sonarqube.mcp.serverapi.views.response.SearchResponse;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class ListPortfoliosTool extends Tool {
 
@@ -32,8 +33,8 @@ public class ListPortfoliosTool extends Tool {
   public static final String QUERY_PROPERTY = "q";
   public static final String FAVORITE_PROPERTY = "favorite";
   public static final String DRAFT_PROPERTY = "draft";
-  public static final String PAGE_INDEX_PROPERTY = "pageIndex";
-  public static final String PAGE_SIZE_PROPERTY = "pageSize";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
 
   private final ServerApiProvider serverApiProvider;
   private final boolean isSonarQubeCloud;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsTool.java
@@ -22,12 +22,13 @@ import org.sonarsource.sonarqube.mcp.serverapi.components.response.SearchRespons
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class SearchMyProjectsTool extends Tool {
 
   public static final String TOOL_NAME = "search_my_sonarqube_projects";
-  public static final String PAGE_PROPERTY = "page";
-  public static final String PAGE_SIZE_PROPERTY = "pageSize";
+  public static final String PAGE_INDEX_PROPERTY = ToolParameters.PAGE_INDEX;
+  public static final String PAGE_SIZE_PROPERTY = ToolParameters.PAGE_SIZE;
   public static final String SEARCH_QUERY_PROPERTY = "q";
   public static final int MAX_PAGE_SIZE = 500;
 
@@ -48,7 +49,7 @@ public class SearchMyProjectsTool extends Tool {
       .setName(TOOL_NAME)
       .setTitle("Search My SonarQube Projects")
       .setDescription(description)
-      .addNumberProperty(PAGE_PROPERTY, "An optional page number. Defaults to 1.")
+      .addNumberProperty(PAGE_INDEX_PROPERTY, "An optional 1-based page index. Defaults to 1.")
       .addNumberProperty(PAGE_SIZE_PROPERTY, "An optional page size. Must be greater than 0 and less than or equal to 500. Defaults to 500.")
       .addStringProperty(SEARCH_QUERY_PROPERTY, "An optional search query to filter projects by name (partial match) or key (exact match).")
       .setReadOnlyHint()
@@ -57,8 +58,8 @@ public class SearchMyProjectsTool extends Tool {
 
   @Override
   public Tool.Result execute(Tool.Arguments arguments) {
-    var page = arguments.getIntOrDefault(PAGE_PROPERTY, 1);
-    var pageSize = arguments.getIntOrDefault(PAGE_SIZE_PROPERTY, MAX_PAGE_SIZE);
+    var page = arguments.getPageIndexOrDefault(1);
+    var pageSize = arguments.getPageSizeOrDefault(MAX_PAGE_SIZE);
     var searchQuery = arguments.getOptionalString(SEARCH_QUERY_PROPERTY);
     
     if (pageSize <= 0 || pageSize > MAX_PAGE_SIZE) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/pullrequests/ListPullRequestsTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/pullrequests/ListPullRequestsTool.java
@@ -21,11 +21,12 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class ListPullRequestsTool extends Tool {
 
   public static final String TOOL_NAME = "list_pull_requests";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
 
   private final ServerApiProvider serverApiProvider;
   @Nullable

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/qualitygates/ProjectStatusTool.java
@@ -22,6 +22,7 @@ import org.sonarsource.sonarqube.mcp.tools.BranchPullRequestContext;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class ProjectStatusTool extends Tool {
 
@@ -29,7 +30,7 @@ public class ProjectStatusTool extends Tool {
   public static final String ANALYSIS_ID_PROPERTY = "analysisId";
   public static final String BRANCH_PROPERTY = BranchPullRequestContext.BRANCH_PROPERTY;
   public static final String PROJECT_ID_PROPERTY = "projectId";
-  public static final String PROJECT_KEY_PROPERTY = "projectKey";
+  public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String PULL_REQUEST_PROPERTY = BranchPullRequestContext.PULL_REQUEST_PROPERTY;
 
   private final ServerApiProvider serverApiProvider;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/webhooks/CreateWebhookTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/webhooks/CreateWebhookTool.java
@@ -21,13 +21,14 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class CreateWebhookTool extends Tool {
 
   public static final String TOOL_NAME = "create_webhook";
   public static final String NAME_PROPERTY = "name";
   public static final String URL_PROPERTY = "url";
-  public static final String PROJECT_PROPERTY = "projectKey";
+  public static final String PROJECT_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String SECRET_PROPERTY = "secret";
 
   private final ServerApiProvider serverApiProvider;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/webhooks/ListWebhooksTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/webhooks/ListWebhooksTool.java
@@ -23,11 +23,12 @@ import org.sonarsource.sonarqube.mcp.serverapi.webhooks.response.ListResponse;
 import org.sonarsource.sonarqube.mcp.tools.SchemaToolBuilder;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
+import org.sonarsource.sonarqube.mcp.tools.ToolParameters;
 
 public class ListWebhooksTool extends Tool {
 
   public static final String TOOL_NAME = "list_webhooks";
-  public static final String PROJECT_PROPERTY = "projectKey";
+  public static final String PROJECT_PROPERTY = ToolParameters.PROJECT_KEY;
 
   private final ServerApiProvider serverApiProvider;
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/McpSchemaValidationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/McpSchemaValidationTest.java
@@ -334,6 +334,24 @@ class McpSchemaValidationTest {
       .isNotEmpty();
   }
 
+  @SonarQubeMcpServerTest
+  void tool_input_schema_should_use_canonical_parameter_names(SonarQubeMcpServerTestHarness harness) {
+    var legacyPropertyNames = Set.of("p", "ps", "page", "projects", "branchName");
+    var client = harness.newClient();
+    for (var tool : client.listTools()) {
+      var properties = (Map<String, Object>) tool.inputSchema().get("properties");
+      if (properties == null) {
+        continue;
+      }
+      for (var propertyName : properties.keySet()) {
+        assertThat(legacyPropertyNames)
+          .isNotEmpty()
+          .as("Tool '%s' must not expose legacy parameter '%s' in its schema", tool.name(), propertyName)
+          .doesNotContain(propertyName);
+      }
+    }
+  }
+
   private void validateMcpToolSchema(McpSchema.Tool schema) {
     assertThat(schema.name())
       .as("Tool name should not be null or empty (MCP spec requirement)")

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolArgumentsTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolArgumentsTest.java
@@ -419,4 +419,18 @@ class ToolArgumentsTest {
       .hasMessage("Missing required argument: projectKey");
   }
 
+  @Test
+  void getOptionalPageIndex_should_read_pageIndex() {
+    var arguments = new Tool.Arguments(Map.of(ToolParameters.PAGE_INDEX, 3), null);
+
+    assertThat(arguments.getOptionalPageIndex()).isEqualTo(3);
+  }
+
+  @Test
+  void getOptionalPageSize_should_read_pageSize() {
+    var arguments = new Tool.Arguments(Map.of(ToolParameters.PAGE_SIZE, 50), null);
+
+    assertThat(arguments.getOptionalPageSize()).isEqualTo(50);
+  }
+
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisToolTests.java
@@ -88,7 +88,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -129,7 +129,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -169,7 +169,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -197,7 +197,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -222,7 +222,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -243,7 +243,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -275,7 +275,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 
@@ -301,7 +301,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "../../etc/passwd"
       ));
 
@@ -318,7 +318,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/NonExistent.java"
       ));
 
@@ -359,7 +359,7 @@ class RunAdvancedCodeAnalysisToolTests {
       RunAdvancedCodeAnalysisTool.TOOL_NAME,
       Map.of(
         "projectKey", "my-project",
-        "branchName", "main",
+        "branch", "main",
         "filePath", "src/Main.java"
       ));
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/hotspots/SearchSecurityHotspotsToolTests.java
@@ -338,7 +338,7 @@ class SearchSecurityHotspotsToolTests {
         SearchSecurityHotspotsTool.TOOL_NAME,
         Map.of(
           SearchSecurityHotspotsTool.PROJECT_KEY_PROPERTY, "my-project",
-          SearchSecurityHotspotsTool.PAGE_PROPERTY, 2,
+          SearchSecurityHotspotsTool.PAGE_INDEX_PROPERTY, 2,
           SearchSecurityHotspotsTool.PAGE_SIZE_PROPERTY, 50));
 
       assertResultEquals(result, """

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
@@ -206,7 +206,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"}));
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, List.of("project1", "project2")));
 
       assertResultEquals(result, """
         {
@@ -262,8 +262,8 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"},
-          SearchIssuesTool.SEVERITIES_PROPERTY, new String[] {"HIGH", "BLOCKER"}));
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, List.of("project1", "project2"),
+          SearchIssuesTool.SEVERITIES_PROPERTY, List.of("HIGH", "BLOCKER")));
 
       assertResultEquals(result, """
         {
@@ -319,7 +319,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.FILES_PROPERTY, new String[] {"file1", "file2"}));
+        Map.of(SearchIssuesTool.FILES_PROPERTY, List.of("file1", "file2")));
 
       assertResultEquals(result, """
         {
@@ -662,7 +662,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"}));
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, List.of("project1", "project2")));
 
       assertResultEquals(result, """
         {
@@ -717,8 +717,8 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"},
-          SearchIssuesTool.SEVERITIES_PROPERTY, new String[] {"HIGH", "BLOCKER"}));
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, List.of("project1", "project2"),
+          SearchIssuesTool.SEVERITIES_PROPERTY, List.of("HIGH", "BLOCKER")));
 
       assertResultEquals(result, """
         {
@@ -773,7 +773,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.FILES_PROPERTY, new String[] {"file1", "file2"}));
+        Map.of(SearchIssuesTool.FILES_PROPERTY, List.of("file1", "file2")));
 
       assertResultEquals(result, """
         {
@@ -1176,7 +1176,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.IMPACT_SOFTWARE_QUALITIES_PROPERTY, new String[] {"MAINTAINABILITY", "SECURITY"}));
+        Map.of(SearchIssuesTool.IMPACT_SOFTWARE_QUALITIES_PROPERTY, List.of("MAINTAINABILITY", "SECURITY")));
 
       assertResultEquals(result, """
         {
@@ -1232,7 +1232,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.ISSUE_STATUSES_PROPERTY, new String[] {"OPEN", "CONFIRMED", "FALSE_POSITIVE"}));
+        Map.of(SearchIssuesTool.ISSUE_STATUSES_PROPERTY, List.of("OPEN", "CONFIRMED", "FALSE_POSITIVE")));
 
       assertResultEquals(result, """
         {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/SearchIssuesToolTests.java
@@ -206,7 +206,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECTS_PROPERTY, new String[] {"project1", "project2"}));
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"}));
 
       assertResultEquals(result, """
         {
@@ -262,7 +262,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECTS_PROPERTY, new String[] {"project1", "project2"},
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"},
           SearchIssuesTool.SEVERITIES_PROPERTY, new String[] {"HIGH", "BLOCKER"}));
 
       assertResultEquals(result, """
@@ -375,7 +375,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PAGE_PROPERTY, 2));
+        Map.of(SearchIssuesTool.PAGE_INDEX_PROPERTY, 2));
 
       assertResultEquals(result, """
         {
@@ -542,7 +542,7 @@ class SearchIssuesToolTests {
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
         Map.of(
-          SearchIssuesTool.PAGE_PROPERTY, 2,
+          SearchIssuesTool.PAGE_INDEX_PROPERTY, 2,
           SearchIssuesTool.PAGE_SIZE_PROPERTY, 50));
 
       assertResultEquals(result, """
@@ -662,7 +662,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECTS_PROPERTY, new String[] {"project1", "project2"}));
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"}));
 
       assertResultEquals(result, """
         {
@@ -717,7 +717,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PROJECTS_PROPERTY, new String[] {"project1", "project2"},
+        Map.of(SearchIssuesTool.PROJECT_KEYS_PROPERTY, new String[] {"project1", "project2"},
           SearchIssuesTool.SEVERITIES_PROPERTY, new String[] {"HIGH", "BLOCKER"}));
 
       assertResultEquals(result, """
@@ -955,7 +955,7 @@ class SearchIssuesToolTests {
 
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
-        Map.of(SearchIssuesTool.PAGE_PROPERTY, 2));
+        Map.of(SearchIssuesTool.PAGE_INDEX_PROPERTY, 2));
 
       assertResultEquals(result, """
         {
@@ -1120,7 +1120,7 @@ class SearchIssuesToolTests {
       var result = mcpClient.callTool(
         SearchIssuesTool.TOOL_NAME,
         Map.of(
-          SearchIssuesTool.PAGE_PROPERTY, 2,
+          SearchIssuesTool.PAGE_INDEX_PROPERTY, 2,
           SearchIssuesTool.PAGE_SIZE_PROPERTY, 50));
 
       assertResultEquals(result, """

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
@@ -18,6 +18,7 @@ package org.sonarsource.sonarqube.mcp.tools.measures;
 
 import com.github.tomakehurst.wiremock.http.Body;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.sonarsource.sonarqube.mcp.harness.ReceivedRequest;
@@ -381,7 +382,7 @@ class GetComponentMeasuresToolTests {
         GetComponentMeasuresTool.TOOL_NAME,
         Map.of(
           GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT:ElementImpl.java",
-          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, new String[]{"ncloc", "complexity"}
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, List.of("ncloc", "complexity")
         ));
 
       assertResultEquals(result, """
@@ -619,7 +620,7 @@ class GetComponentMeasuresToolTests {
         GetComponentMeasuresTool.TOOL_NAME,
         Map.of(
           GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "org.sonarsource.sonarlint.core:sonarlint-core-parent",
-          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, new String[]{"coverage", "ncloc"}
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, List.of("coverage", "ncloc")
         ));
 
       assertResultEquals(result, """
@@ -843,7 +844,7 @@ class GetComponentMeasuresToolTests {
         GetComponentMeasuresTool.TOOL_NAME,
         Map.of(
           GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT:ElementImpl.java",
-          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, new String[]{"ncloc", "complexity"}
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, List.of("ncloc", "complexity")
         ));
 
       assertResultEquals(result, """
@@ -1075,7 +1076,7 @@ class GetComponentMeasuresToolTests {
         GetComponentMeasuresTool.TOOL_NAME,
         Map.of(
           GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "org.sonarsource.sonarlint.core:sonarlint-core-parent",
-          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, new String[]{"coverage", "ncloc"}
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, List.of("coverage", "ncloc")
         ));
 
       assertResultEquals(result, """

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/metrics/SearchMetricsToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/metrics/SearchMetricsToolTests.java
@@ -225,7 +225,7 @@ class SearchMetricsToolTests {
       var result = mcpClient.callTool(
         SearchMetricsTool.TOOL_NAME,
         Map.of(
-          SearchMetricsTool.PAGE_PROPERTY, 2,
+          SearchMetricsTool.PAGE_INDEX_PROPERTY, 2,
           SearchMetricsTool.PAGE_SIZE_PROPERTY, 20
         ));
 
@@ -359,7 +359,7 @@ class SearchMetricsToolTests {
       var result = mcpClient.callTool(
         SearchMetricsTool.TOOL_NAME,
         Map.of(
-          SearchMetricsTool.PAGE_PROPERTY, 2,
+          SearchMetricsTool.PAGE_INDEX_PROPERTY, 2,
           SearchMetricsTool.PAGE_SIZE_PROPERTY, 20
         ));
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/projects/SearchMyProjectsToolTests.java
@@ -181,7 +181,7 @@ class SearchMyProjectsToolTests {
 
       var result = mcpClient.callTool(
         SearchMyProjectsTool.TOOL_NAME,
-        Map.of("page", 2));
+        Map.of("pageIndex", 2));
 
       assertResultEquals(result, """
         {
@@ -282,7 +282,7 @@ class SearchMyProjectsToolTests {
 
       var result = mcpClient.callTool(
         SearchMyProjectsTool.TOOL_NAME,
-        Map.of("page", 2, "pageSize", 100, "q", "test"));
+        Map.of("pageIndex", 2, "pageSize", 100, "q", "test"));
 
       assertResultEquals(result, """
         {
@@ -351,7 +351,7 @@ class SearchMyProjectsToolTests {
 
       var result = mcpClient.callTool(
         SearchMyProjectsTool.TOOL_NAME,
-        Map.of("page", 2));
+        Map.of("pageIndex", 2));
 
       assertResultEquals(result, """
         {
@@ -436,7 +436,7 @@ class SearchMyProjectsToolTests {
 
       var result = mcpClient.callTool(
         SearchMyProjectsTool.TOOL_NAME,
-        Map.of("page", 2, "pageSize", 100, "q", "test"));
+        Map.of("pageIndex", 2, "pageSize", 100, "q", "test"));
 
       assertResultEquals(result, """
         {


### PR DESCRIPTION
----
## Summary by Gitar

- **Tool Parameter Standardization:**
  - Introduced `ToolParameters` to define canonical names for `projectKey`, `projectKeys`, `pageIndex`, and `pageSize`.
  - Migrated all tools to use these shared constants, replacing legacy properties like `p`, `ps`, and `page`.
- **Framework Improvements:**
  - Added helper methods `getOptionalPageIndex` and `getOptionalPageSize` to the base `Tool` class.
  - Enhanced `getOptionalStringList` to support both `List` and array input types from MCP arguments.
- **Testing and Documentation:**
  - Updated `README.md` to reflect new parameter names across all tools.
  - Added `McpSchemaValidationTest` to prevent re-introduction of legacy parameter names in tool schemas.
  - Updated various integration tests to align with the new parameter naming convention.


<sub>This will update automatically on new commits.</sub>