### PR TITLE
MCP-548 Remove unused GitHub Action workflow parameter

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,6 @@ jobs:
         with:
           name: multibuilder
           driver: docker-container
-          install: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -167,7 +166,6 @@ jobs:
         with:
           name: multibuilder
           driver: docker-container
-          install: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Removed unused parameter from `.github/workflows/docker-publish.yml` to clean up the workflow definition.

<sub>This will update automatically on new commits.</sub>