### PR TITLE
MCP-550 Auto-detect SonarQube Cloud Organization (Single Org)

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -54,6 +54,7 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApiHelper;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.features.Feature;
 import org.sonarsource.sonarqube.mcp.serverapi.organizations.OrganizationsApi;
+import org.sonarsource.sonarqube.mcp.serverapi.organizations.ResolvedOrganization;
 import org.sonarsource.sonarqube.mcp.slcore.BackendService;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -176,14 +177,11 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   @Nullable
   private ServerApi serverApi;
   /**
-   * Effective SonarQube Cloud organization used by the stdio startup path.
-   * Initialized from {@code SONARQUBE_ORG}; when unset in stdio Cloud mode it may be auto-detected from the token
-   * (see {@link #autoDetectOrganizationIfNeeded()}). The HTTP path resolves the organization per request instead.
+   * Effective SonarQube Cloud organization for the stdio session (key and optional cached UUID v4).
+   * Set by {@link #resolveOrganizationAtStartup()}. HTTP mode resolves organization per request instead.
    */
   @Nullable
-  private String resolvedOrganization;
-  @Nullable
-  private String resolvedOrganizationUuidV4;
+  private ResolvedOrganization resolvedOrganization;
   private SonarQubeVersionChecker sonarQubeVersionChecker;
   @Nullable
   private McpStatelessSyncServer statelessSyncServer;
@@ -283,13 +281,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       ? new ToolExecutor(backendService, analyticsService, null, this, mcpConfiguration.getMcpServerId())
       : new ToolExecutor(backendService, analyticsService, connectionContext, null, mcpConfiguration.getMcpServerId());
 
-    this.resolvedOrganization = mcpConfiguration.getSonarqubeOrg();
-
-    // Create ServerApi for startup probing (version check, SCA availability, plugin sync).
-    // In HTTP mode this is optional — only created when a startup token is configured.
-    // Per-request tool calls in HTTP mode always use a fresh ServerApi from the request headers.
     this.serverApi = initializeServerApi(mcpConfiguration);
-    autoDetectOrganizationIfNeeded();
+    resolveOrganizationAtStartup();
     this.sonarQubeVersionChecker = new SonarQubeVersionChecker(serverApi);
     loadBackendIndependentTools(serverApi);
 
@@ -450,13 +443,14 @@ public class SonarQubeMcpServer implements ServerApiProvider {
 
   }
 
-  private boolean isSaraEnabled(@Nullable ServerApi api, @Nullable String orgKey) {
-    if (api == null || orgKey == null || orgKey.isBlank()) {
+  private boolean isSaraEnabled(@Nullable ServerApi api, @Nullable ResolvedOrganization org) {
+    if (api == null || org == null) {
       LOG.debug("Agentic readiness feature flag check skipped: no org key configured");
       return false;
     }
+    var orgKey = org.key();
     try {
-      var orgUuidV4 = organizationUuidV4(api, orgKey);
+      var orgUuidV4 = uuidV4(api, org);
       if (orgUuidV4 == null) {
         LOG.debug("Agentic readiness feature flag check: could not resolve UUID for org '" + orgKey + "' - skipping");
         return false;
@@ -470,18 +464,19 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     }
   }
 
-  private boolean isAdvancedAnalysisEnabledForOrg(@Nullable ServerApi api, @Nullable String orgKey) {
-    if (api == null || orgKey == null) {
+  private boolean isAdvancedAnalysisEnabledForOrg(@Nullable ServerApi api, @Nullable ResolvedOrganization org) {
+    if (api == null || org == null) {
       return false;
     }
-    return RunAdvancedCodeAnalysisTool.isA3sEnabled(api, orgKey, organizationUuidV4(api, orgKey));
+    return RunAdvancedCodeAnalysisTool.isA3sEnabled(api, uuidV4(api, org), org.key());
   }
 
-  private boolean isCagEnabledForOrg(@Nullable ServerApi api, @Nullable String orgKey) {
-    if (api == null || orgKey == null) {
+  private boolean isCagEnabledForOrg(@Nullable ServerApi api, @Nullable ResolvedOrganization org) {
+    if (api == null || org == null) {
       return false;
     }
-    var orgUuidV4 = organizationUuidV4(api, orgKey);
+    var orgKey = org.key();
+    var orgUuidV4 = uuidV4(api, org);
     if (orgUuidV4 == null) {
       LOG.debug("CAG entitlement check: could not resolve UUID for org '" + orgKey + "' - skipping CAG");
       return false;
@@ -498,11 +493,15 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   }
 
   @Nullable
-  private String organizationUuidV4(ServerApi api, String orgKey) {
-    if (orgKey.equals(resolvedOrganization) && resolvedOrganizationUuidV4 != null) {
-      return resolvedOrganizationUuidV4;
+  private String uuidV4(ServerApi api, ResolvedOrganization org) {
+    if (org.uuidV4() != null) {
+      return org.uuidV4();
     }
-    return api.organizationsApi().getOrganizationUuidV4(orgKey);
+    var fetched = api.organizationsApi().getOrganizationUuidV4(org.key());
+    if (fetched != null && org == resolvedOrganization) {
+      this.resolvedOrganization = new ResolvedOrganization(org.key(), fetched);
+    }
+    return fetched;
   }
 
   /**
@@ -644,7 +643,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     LOG.info("Instance: " + sonarQubeType);
     LOG.info("URL: " + mcpConfiguration.getSonarQubeUrl());
     if (mcpConfiguration.isSonarQubeCloud() && resolvedOrganization != null) {
-      LOG.info("Organization: " + resolvedOrganization);
+      LOG.info("Organization: " + resolvedOrganization.key());
     }
     if (mcpConfiguration.isReadOnlyMode()) {
       LOG.info("Mode: READ-ONLY (write operations disabled)");
@@ -718,13 +717,16 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   }
 
   /**
-   * In stdio mode connecting to SonarQube Cloud without an explicit {@code SONARQUBE_ORG}, resolves the
-   * organization from the authenticated token. When the token belongs to exactly one organization it is
-   * adopted automatically and the startup {@link ServerApi} is rebuilt with it. Zero or multiple organizations
-   * fail startup with an actionable message (multi-org selection tooling is tracked separately in MCP-551).
+   * Resolves the effective SonarQube Cloud organization for stdio startup.
+   * Uses {@code SONARQUBE_ORG} when set; otherwise auto-detects from the token when it belongs to exactly one organization.
    */
-  private void autoDetectOrganizationIfNeeded() {
-    if (mcpConfiguration.isHttpEnabled() || !mcpConfiguration.isSonarQubeCloud() || resolvedOrganization != null) {
+  private void resolveOrganizationAtStartup() {
+    var configuredOrgKey = mcpConfiguration.getSonarqubeOrg();
+    if (configuredOrgKey != null) {
+      this.resolvedOrganization = ResolvedOrganization.fromKey(configuredOrgKey);
+      return;
+    }
+    if (mcpConfiguration.isHttpEnabled() || !mcpConfiguration.isSonarQubeCloud()) {
       return;
     }
     var token = mcpConfiguration.getSonarQubeToken();
@@ -740,10 +742,9 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     }
     if (organizations.size() == 1) {
       var organization = organizations.getFirst();
-      this.resolvedOrganization = organization.key();
-      this.resolvedOrganizationUuidV4 = organization.uuidV4();
+      this.resolvedOrganization = ResolvedOrganization.from(organization);
       this.serverApi = createServerApiWithToken(token);
-      LOG.info("Auto-selected SonarQube Cloud organization: " + resolvedOrganization);
+      LOG.info("Auto-selected SonarQube Cloud organization: " + resolvedOrganization.key());
     } else if (organizations.isEmpty()) {
       throw new IllegalStateException("No SonarQube Cloud organization is associated with the provided token. " +
         "Set SONARQUBE_ORG to the organization you want to use.");
@@ -755,7 +756,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   }
 
   private ServerApi createServerApiWithToken(@Nullable String token) {
-    return createServerApiWithTokenAndOrg(token, resolvedOrganization);
+    var orgKey = resolvedOrganization != null ? resolvedOrganization.key() : null;
+    return createServerApiWithTokenAndOrg(token, orgKey);
   }
 
   private ServerApi createServerApiWithTokenAndOrg(@Nullable String token, @Nullable String organization) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -182,6 +182,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
    */
   @Nullable
   private String resolvedOrganization;
+  @Nullable
+  private String resolvedOrganizationUuidV4;
   private SonarQubeVersionChecker sonarQubeVersionChecker;
   @Nullable
   private McpStatelessSyncServer statelessSyncServer;
@@ -448,13 +450,13 @@ public class SonarQubeMcpServer implements ServerApiProvider {
 
   }
 
-  private static boolean isSaraEnabled(@Nullable ServerApi api, @Nullable String orgKey) {
+  private boolean isSaraEnabled(@Nullable ServerApi api, @Nullable String orgKey) {
     if (api == null || orgKey == null || orgKey.isBlank()) {
       LOG.debug("Agentic readiness feature flag check skipped: no org key configured");
       return false;
     }
     try {
-      var orgUuidV4 = api.organizationsApi().getOrganizationUuidV4(orgKey);
+      var orgUuidV4 = organizationUuidV4(api, orgKey);
       if (orgUuidV4 == null) {
         LOG.debug("Agentic readiness feature flag check: could not resolve UUID for org '" + orgKey + "' - skipping");
         return false;
@@ -468,18 +470,18 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     }
   }
 
-  private static boolean isAdvancedAnalysisEnabledForOrg(@Nullable ServerApi api, @Nullable String orgKey) {
+  private boolean isAdvancedAnalysisEnabledForOrg(@Nullable ServerApi api, @Nullable String orgKey) {
     if (api == null || orgKey == null) {
       return false;
     }
-    return RunAdvancedCodeAnalysisTool.isA3sEnabled(api, orgKey);
+    return RunAdvancedCodeAnalysisTool.isA3sEnabled(api, orgKey, organizationUuidV4(api, orgKey));
   }
 
-  private static boolean isCagEnabledForOrg(@Nullable ServerApi api, @Nullable String orgKey) {
+  private boolean isCagEnabledForOrg(@Nullable ServerApi api, @Nullable String orgKey) {
     if (api == null || orgKey == null) {
       return false;
     }
-    var orgUuidV4 = api.organizationsApi().getOrganizationUuidV4(orgKey);
+    var orgUuidV4 = organizationUuidV4(api, orgKey);
     if (orgUuidV4 == null) {
       LOG.debug("CAG entitlement check: could not resolve UUID for org '" + orgKey + "' - skipping CAG");
       return false;
@@ -493,6 +495,14 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       LOG.debug("CAG entitlement check: org '" + orgKey + "' is not entitled to use CAG");
     }
     return entitlement.allowed();
+  }
+
+  @Nullable
+  private String organizationUuidV4(ServerApi api, String orgKey) {
+    if (orgKey.equals(resolvedOrganization) && resolvedOrganizationUuidV4 != null) {
+      return resolvedOrganizationUuidV4;
+    }
+    return api.organizationsApi().getOrganizationUuidV4(orgKey);
   }
 
   /**
@@ -729,7 +739,9 @@ public class SonarQubeMcpServer implements ServerApiProvider {
         "Verify the token is valid, or set SONARQUBE_ORG explicitly.", e);
     }
     if (organizations.size() == 1) {
-      this.resolvedOrganization = organizations.getFirst().key();
+      var organization = organizations.getFirst();
+      this.resolvedOrganization = organization.key();
+      this.resolvedOrganizationUuidV4 = organization.uuidV4();
       this.serverApi = createServerApiWithToken(token);
       LOG.info("Auto-selected SonarQube Cloud organization: " + resolvedOrganization);
     } else if (organizations.isEmpty()) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -281,6 +281,10 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       ? new ToolExecutor(backendService, analyticsService, null, this, mcpConfiguration.getMcpServerId())
       : new ToolExecutor(backendService, analyticsService, connectionContext, null, mcpConfiguration.getMcpServerId());
 
+    var configuredOrgKey = mcpConfiguration.getSonarqubeOrg();
+    if (configuredOrgKey != null) {
+      this.resolvedOrganization = ResolvedOrganization.fromKey(configuredOrgKey);
+    }
     this.serverApi = initializeServerApi(mcpConfiguration);
     resolveOrganizationAtStartup();
     this.sonarQubeVersionChecker = new SonarQubeVersionChecker(serverApi);
@@ -717,16 +721,11 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   }
 
   /**
-   * Resolves the effective SonarQube Cloud organization for stdio startup.
-   * Uses {@code SONARQUBE_ORG} when set; otherwise auto-detects from the token when it belongs to exactly one organization.
+   * Auto-detects the SonarQube Cloud organization in stdio mode when {@code SONARQUBE_ORG} is unset.
+   * When the token belongs to exactly one organization it is adopted and the startup {@link ServerApi} is rebuilt.
    */
   private void resolveOrganizationAtStartup() {
-    var configuredOrgKey = mcpConfiguration.getSonarqubeOrg();
-    if (configuredOrgKey != null) {
-      this.resolvedOrganization = ResolvedOrganization.fromKey(configuredOrgKey);
-      return;
-    }
-    if (mcpConfiguration.isHttpEnabled() || !mcpConfiguration.isSonarQubeCloud()) {
+    if (resolvedOrganization != null || mcpConfiguration.isHttpEnabled() || !mcpConfiguration.isSonarQubeCloud()) {
       return;
     }
     var token = mcpConfiguration.getSonarQubeToken();

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -53,6 +53,7 @@ import org.sonarsource.sonarqube.mcp.serverapi.ServerApi;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiHelper;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiProvider;
 import org.sonarsource.sonarqube.mcp.serverapi.features.Feature;
+import org.sonarsource.sonarqube.mcp.serverapi.organizations.OrganizationsApi;
 import org.sonarsource.sonarqube.mcp.slcore.BackendService;
 import org.sonarsource.sonarqube.mcp.tools.Tool;
 import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
@@ -174,6 +175,13 @@ public class SonarQubeMcpServer implements ServerApiProvider {
    */
   @Nullable
   private ServerApi serverApi;
+  /**
+   * Effective SonarQube Cloud organization used by the stdio startup path.
+   * Initialized from {@code SONARQUBE_ORG}; when unset in stdio Cloud mode it may be auto-detected from the token
+   * (see {@link #autoDetectOrganizationIfNeeded()}). The HTTP path resolves the organization per request instead.
+   */
+  @Nullable
+  private String resolvedOrganization;
   private SonarQubeVersionChecker sonarQubeVersionChecker;
   @Nullable
   private McpStatelessSyncServer statelessSyncServer;
@@ -273,10 +281,13 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       ? new ToolExecutor(backendService, analyticsService, null, this, mcpConfiguration.getMcpServerId())
       : new ToolExecutor(backendService, analyticsService, connectionContext, null, mcpConfiguration.getMcpServerId());
 
+    this.resolvedOrganization = mcpConfiguration.getSonarqubeOrg();
+
     // Create ServerApi for startup probing (version check, SCA availability, plugin sync).
     // In HTTP mode this is optional — only created when a startup token is configured.
     // Per-request tool calls in HTTP mode always use a fresh ServerApi from the request headers.
     this.serverApi = initializeServerApi(mcpConfiguration);
+    autoDetectOrganizationIfNeeded();
     this.sonarQubeVersionChecker = new SonarQubeVersionChecker(serverApi);
     loadBackendIndependentTools(serverApi);
 
@@ -297,7 +308,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       LOG.debug("HTTP mode detected - skipping CAG proxied server initialization (not supported in HTTP transport)");
     } else if (!mcpConfiguration.isToolCategoryEnabled(ToolCategory.CAG)) {
       LOG.debug("CAG toolset is not enabled, skipping proxied server initialization");
-    } else if (isCagEnabledForOrg(serverApi, mcpConfiguration.getSonarqubeOrg())) {
+    } else if (isCagEnabledForOrg(serverApi, resolvedOrganization)) {
       LOG.info("CAG is enabled for organization");
       loadProxiedServerTools();
     } else {
@@ -309,7 +320,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
 
     var workspaceMount = mcpConfiguration.getWorkspacePath();
 
-    if (!mcpConfiguration.isHttpEnabled() && isAdvancedAnalysisEnabledForOrg(serverApi, mcpConfiguration.getSonarqubeOrg())) {
+    if (!mcpConfiguration.isHttpEnabled() && isAdvancedAnalysisEnabledForOrg(serverApi, resolvedOrganization)) {
       if (workspaceMount != null) {
         LOG.info("Advanced analysis mode enabled");
         supportedTools.add(new RunAdvancedCodeAnalysisTool(this, mcpConfiguration.getProjectKey(), workspaceMount));
@@ -551,7 +562,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       return true;
     }
     // stdio mode: a single organization is fixed at startup, so probe the feature flag once here.
-    if (!isSaraEnabled(serverApi, mcpConfiguration.getSonarqubeOrg())) {
+    if (!isSaraEnabled(serverApi, resolvedOrganization)) {
       LOG.debug("Agentic readiness is not enabled for organization, skipping tools initialization");
       return false;
     }
@@ -622,8 +633,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       (mcpConfiguration.isHttpEnabled() ? (" (" + mcpConfiguration.getHttpHost() + ":" + mcpConfiguration.getHttpPort() + ")") : ""));
     LOG.info("Instance: " + sonarQubeType);
     LOG.info("URL: " + mcpConfiguration.getSonarQubeUrl());
-    if (mcpConfiguration.isSonarQubeCloud() && mcpConfiguration.getSonarqubeOrg() != null) {
-      LOG.info("Organization: " + mcpConfiguration.getSonarqubeOrg());
+    if (mcpConfiguration.isSonarQubeCloud() && resolvedOrganization != null) {
+      LOG.info("Organization: " + resolvedOrganization);
     }
     if (mcpConfiguration.isReadOnlyMode()) {
       LOG.info("Mode: READ-ONLY (write operations disabled)");
@@ -695,9 +706,44 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     var token = mcpConfiguration.getSonarQubeToken();
     return createServerApiWithToken(token);
   }
-  
+
+  /**
+   * In stdio mode connecting to SonarQube Cloud without an explicit {@code SONARQUBE_ORG}, resolves the
+   * organization from the authenticated token. When the token belongs to exactly one organization it is
+   * adopted automatically and the startup {@link ServerApi} is rebuilt with it. Zero or multiple organizations
+   * fail startup with an actionable message (multi-org selection tooling is tracked separately in MCP-551).
+   */
+  private void autoDetectOrganizationIfNeeded() {
+    if (mcpConfiguration.isHttpEnabled() || !mcpConfiguration.isSonarQubeCloud() || resolvedOrganization != null) {
+      return;
+    }
+    var token = mcpConfiguration.getSonarQubeToken();
+    if (token == null || serverApi == null) {
+      return;
+    }
+    List<OrganizationsApi.Organization> organizations;
+    try {
+      organizations = serverApi.organizationsApi().listOrganizations();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to list SonarQube Cloud organizations for the provided token. " +
+        "Verify the token is valid, or set SONARQUBE_ORG explicitly.", e);
+    }
+    if (organizations.size() == 1) {
+      this.resolvedOrganization = organizations.getFirst().key();
+      this.serverApi = createServerApiWithToken(token);
+      LOG.info("Auto-selected SonarQube Cloud organization: " + resolvedOrganization);
+    } else if (organizations.isEmpty()) {
+      throw new IllegalStateException("No SonarQube Cloud organization is associated with the provided token. " +
+        "Set SONARQUBE_ORG to the organization you want to use.");
+    } else {
+      var keys = organizations.stream().map(OrganizationsApi.Organization::key).sorted().toList();
+      throw new IllegalStateException("The provided token is associated with multiple SonarQube Cloud organizations " +
+        keys + ". Set SONARQUBE_ORG to the organization you want to use.");
+    }
+  }
+
   private ServerApi createServerApiWithToken(@Nullable String token) {
-    return createServerApiWithTokenAndOrg(token, mcpConfiguration.getSonarqubeOrg());
+    return createServerApiWithTokenAndOrg(token, resolvedOrganization);
   }
 
   private ServerApi createServerApiWithTokenAndOrg(@Nullable String token, @Nullable String organization) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -167,7 +167,6 @@ public class McpServerLaunchConfiguration {
     }
 
     var forceSonarQubeCloud = Boolean.parseBoolean(getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_IS_CLOUD, "false"));
-    validateStdioConfiguration(isHttpEnabled, sonarqubeUrlFromEnv, this.sonarqubeOrg);
     this.isSonarQubeCloud = resolveSonarQubeCloud(forceSonarQubeCloud, this.sonarqubeOrg, sonarqubeUrlFromEnv);
     this.sonarqubeUrl = resolveUrl(this.isSonarQubeCloud, sonarqubeUrlFromEnv);
 
@@ -398,21 +397,6 @@ public class McpServerLaunchConfiguration {
       return port;
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("Invalid SONARQUBE_HTTP_PORT value: " + portStr, e);
-    }
-  }
-
-  /**
-   * In stdio mode, either SONARQUBE_URL or SONARQUBE_ORG must be set.
-   * There is no per-request org resolution, so connecting to SonarQube without a URL or org key makes no sense.
-   * In HTTP mode, no validation is needed: the server defaults to sonarcloud.io and resolves from the Authorization header at request time.
-   */
-  private static void validateStdioConfiguration(boolean isHttpEnabled, @Nullable String url, @Nullable String org) {
-    if (!isHttpEnabled && url == null && org == null) {
-      throw new IllegalArgumentException(
-        "SONARQUBE_URL or SONARQUBE_ORG must be set. " +
-          "Set SONARQUBE_URL to your SonarQube Server URL or SonarQube Cloud URL, " +
-          "or set SONARQUBE_ORG to connect to SonarQube Cloud."
-      );
     }
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -422,7 +422,7 @@ public class McpServerLaunchConfiguration {
    *   1. SONARQUBE_IS_CLOUD=true → explicit override
    *   2. SONARQUBE_ORG set → org implies SQC
    *   3. SONARQUBE_URL is a known SQC hostname (sonarcloud.io, sonarqube.us, …)
-   *   4. No SONARQUBE_URL → default to SQC (HTTP mode only)
+   *   4. No SONARQUBE_URL → Cloud when HTTP transport is enabled (defaults to sonarcloud.io); stdio requires URL or ORG (see validateStdioConfiguration)
    *   5. SONARQUBE_URL is unknown host → SQS
    */
   private static boolean resolveSonarQubeCloud(boolean forceSonarCloud, @Nullable String org, @Nullable String url, boolean isHttpEnabled) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -167,7 +167,7 @@ public class McpServerLaunchConfiguration {
     }
 
     var forceSonarQubeCloud = Boolean.parseBoolean(getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_IS_CLOUD, "false"));
-    validateStdioConfiguration(isHttpEnabled, sonarqubeUrlFromEnv, this.sonarqubeOrg, forceSonarQubeCloud);
+    validateStdioConfiguration(isHttpEnabled, sonarqubeUrlFromEnv, this.sonarqubeOrg);
     this.isSonarQubeCloud = resolveSonarQubeCloud(forceSonarQubeCloud, this.sonarqubeOrg, sonarqubeUrlFromEnv, isHttpEnabled);
     this.sonarqubeUrl = resolveUrl(this.isSonarQubeCloud, sonarqubeUrlFromEnv);
 
@@ -402,16 +402,16 @@ public class McpServerLaunchConfiguration {
   }
 
   /**
-   * In stdio mode, require an explicit connection target so a forgotten SONARQUBE_URL does not silently
-   * send the token to SonarQube Cloud. HTTP mode may omit the URL and defaults to sonarcloud.io.
+   * In stdio mode, either SONARQUBE_URL or SONARQUBE_ORG must be set.
+   * There is no per-request org resolution, so connecting without a URL or org key makes no sense.
+   * In HTTP mode, no validation is needed: the server defaults to sonarcloud.io and resolves from the Authorization header at request time.
    */
-  private static void validateStdioConfiguration(boolean isHttpEnabled, @Nullable String url, @Nullable String org, boolean forceSonarQubeCloud) {
-    if (!isHttpEnabled && url == null && org == null && !forceSonarQubeCloud) {
+  private static void validateStdioConfiguration(boolean isHttpEnabled, @Nullable String url, @Nullable String org) {
+    if (!isHttpEnabled && url == null && org == null) {
       throw new IllegalArgumentException(
-        "SONARQUBE_URL, SONARQUBE_ORG, or SONARQUBE_IS_CLOUD=true must be set. " +
+        "SONARQUBE_URL or SONARQUBE_ORG must be set. " +
           "Set SONARQUBE_URL to your SonarQube Server URL or SonarQube Cloud URL, " +
-          "set SONARQUBE_ORG to connect to a specific SonarQube Cloud organization, " +
-          "or set SONARQUBE_IS_CLOUD=true to connect to SonarQube Cloud with automatic organization detection."
+          "or set SONARQUBE_ORG to connect to SonarQube Cloud."
       );
     }
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -167,7 +167,8 @@ public class McpServerLaunchConfiguration {
     }
 
     var forceSonarQubeCloud = Boolean.parseBoolean(getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_IS_CLOUD, "false"));
-    this.isSonarQubeCloud = resolveSonarQubeCloud(forceSonarQubeCloud, this.sonarqubeOrg, sonarqubeUrlFromEnv);
+    validateStdioConfiguration(isHttpEnabled, sonarqubeUrlFromEnv, this.sonarqubeOrg, forceSonarQubeCloud);
+    this.isSonarQubeCloud = resolveSonarQubeCloud(forceSonarQubeCloud, this.sonarqubeOrg, sonarqubeUrlFromEnv, isHttpEnabled);
     this.sonarqubeUrl = resolveUrl(this.isSonarQubeCloud, sonarqubeUrlFromEnv);
 
     this.sonarqubeCloudApiUrl = getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_CLOUD_API_URL, null);
@@ -401,22 +402,40 @@ public class McpServerLaunchConfiguration {
   }
 
   /**
+   * In stdio mode, require an explicit connection target so a forgotten SONARQUBE_URL does not silently
+   * send the token to SonarQube Cloud. HTTP mode may omit the URL and defaults to sonarcloud.io.
+   */
+  private static void validateStdioConfiguration(boolean isHttpEnabled, @Nullable String url, @Nullable String org, boolean forceSonarQubeCloud) {
+    if (!isHttpEnabled && url == null && org == null && !forceSonarQubeCloud) {
+      throw new IllegalArgumentException(
+        "SONARQUBE_URL, SONARQUBE_ORG, or SONARQUBE_IS_CLOUD=true must be set. " +
+          "Set SONARQUBE_URL to your SonarQube Server URL or SonarQube Cloud URL, " +
+          "set SONARQUBE_ORG to connect to a specific SonarQube Cloud organization, " +
+          "or set SONARQUBE_IS_CLOUD=true to connect to SonarQube Cloud with automatic organization detection."
+      );
+    }
+  }
+
+  /**
    * Resolves whether the server is connecting to SonarQube Cloud.
    * Signal priority (highest to lowest):
    *   1. SONARQUBE_IS_CLOUD=true → explicit override
    *   2. SONARQUBE_ORG set → org implies SQC
    *   3. SONARQUBE_URL is a known SQC hostname (sonarcloud.io, sonarqube.us, …)
-   *   4. No SONARQUBE_URL → default to SQC (HTTP mode only after stdio validation)
+   *   4. No SONARQUBE_URL → default to SQC (HTTP mode only)
    *   5. SONARQUBE_URL is unknown host → SQS
    */
-  private static boolean resolveSonarQubeCloud(boolean forceSonarCloud, @Nullable String org, @Nullable String url) {
-    return forceSonarCloud || org != null || url == null || isSonarQubeCloudUrl(url);
+  private static boolean resolveSonarQubeCloud(boolean forceSonarCloud, @Nullable String org, @Nullable String url, boolean isHttpEnabled) {
+    if (forceSonarCloud || org != null || isSonarQubeCloudUrl(url)) {
+      return true;
+    }
+    return url == null && isHttpEnabled;
   }
 
   /**
    * Resolves the effective server URL.
    * For SQC without an explicit URL, defaults to sonarcloud.io.
-   * For SQS, the URL is guaranteed non-null at this point (stdio validation ensures this).
+   * For SQS, the URL must be set explicitly in stdio mode.
    */
   private static String resolveUrl(boolean isSonarQubeCloud, @Nullable String url) {
     if (isSonarQubeCloud) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/organizations/OrganizationsApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/organizations/OrganizationsApi.java
@@ -19,6 +19,8 @@ package org.sonarsource.sonarqube.mcp.serverapi.organizations;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import jakarta.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
 import org.sonarsource.sonarqube.mcp.log.McpLogger;
 import org.sonarsource.sonarqube.mcp.serverapi.ServerApiHelper;
 import org.sonarsource.sonarqube.mcp.serverapi.UrlBuilder;
@@ -44,7 +46,7 @@ public class OrganizationsApi {
       .addParam("excludeEligibility", "true")
       .build();
     try (var response = helper.getApiSubdomain(path)) {
-      var dtos = new Gson().fromJson(response.bodyAsString(), OrganizationResponse[].class);
+      var dtos = new Gson().fromJson(response.bodyAsString(), Organization[].class);
       if (dtos == null || dtos.length == 0) {
         return null;
       }
@@ -55,7 +57,25 @@ public class OrganizationsApi {
     }
   }
 
-  record OrganizationResponse(String id, @SerializedName("uuidV4") String uuidV4) {
+  /**
+   * Lists the organizations the authenticated user is a member of. Only available on SonarQube Cloud.
+   * Unlike {@link #getOrganizationUuidV4(String)}, this does not swallow errors: HTTP failures
+   * (e.g. invalid token) propagate so callers can distinguish an authentication problem from an empty result.
+   */
+  public List<Organization> listOrganizations() {
+    var path = new UrlBuilder(ORGANIZATIONS_PATH)
+      .addParam("excludeEligibility", "true")
+      .build();
+    try (var response = helper.getApiSubdomain(path)) {
+      var dtos = new Gson().fromJson(response.bodyAsString(), Organization[].class);
+      if (dtos == null) {
+        return List.of();
+      }
+      return Arrays.stream(dtos).toList();
+    }
+  }
+
+  public record Organization(String id, String key, String name, @SerializedName("uuidV4") String uuidV4) {
   }
 
 }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/organizations/ResolvedOrganization.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/organizations/ResolvedOrganization.java
@@ -1,0 +1,35 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.serverapi.organizations;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * SonarQube Cloud organization key and UUID v4 resolved for the current stdio session.
+ * {@code uuidV4} is present when known from {@link OrganizationsApi#listOrganizations()}; otherwise it is fetched on demand.
+ */
+public record ResolvedOrganization(String key, @Nullable String uuidV4) {
+
+  public static ResolvedOrganization fromKey(String key) {
+    return new ResolvedOrganization(key, null);
+  }
+
+  public static ResolvedOrganization from(OrganizationsApi.Organization organization) {
+    return new ResolvedOrganization(organization.key(), organization.uuidV4());
+  }
+
+}

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
@@ -75,10 +75,6 @@ public class RunAdvancedCodeAnalysisTool extends Tool {
       .build();
   }
 
-  public static boolean isA3sEnabled(ServerApi api, String orgKey) {
-    return isA3sEnabled(api, orgKey, null);
-  }
-
   public static boolean isA3sEnabled(ServerApi api, String orgKey, @Nullable String orgUuidV4) {
     var uuid = orgUuidV4 != null ? orgUuidV4 : api.organizationsApi().getOrganizationUuidV4(orgKey);
     if (uuid == null) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
@@ -76,12 +76,16 @@ public class RunAdvancedCodeAnalysisTool extends Tool {
   }
 
   public static boolean isA3sEnabled(ServerApi api, String orgKey) {
-    var orgUuidV4 = api.organizationsApi().getOrganizationUuidV4(orgKey);
-    if (orgUuidV4 == null) {
+    return isA3sEnabled(api, orgKey, null);
+  }
+
+  public static boolean isA3sEnabled(ServerApi api, String orgKey, @Nullable String orgUuidV4) {
+    var uuid = orgUuidV4 != null ? orgUuidV4 : api.organizationsApi().getOrganizationUuidV4(orgKey);
+    if (uuid == null) {
       LOG.debug("A3S entitlement check: could not resolve UUID for org '" + orgKey + "' - falling back to standard analysis");
       return false;
     }
-    var config = api.a3sAnalysisApi().getA3sOrgConfig(orgUuidV4);
+    var config = api.a3sAnalysisApi().getA3sOrgConfig(uuid);
     if (config == null) {
       LOG.debug("A3S entitlement check: could not retrieve org config for org '" + orgKey + "' - falling back to standard analysis");
       return false;

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/RunAdvancedCodeAnalysisTool.java
@@ -75,13 +75,12 @@ public class RunAdvancedCodeAnalysisTool extends Tool {
       .build();
   }
 
-  public static boolean isA3sEnabled(ServerApi api, String orgKey, @Nullable String orgUuidV4) {
-    var uuid = orgUuidV4 != null ? orgUuidV4 : api.organizationsApi().getOrganizationUuidV4(orgKey);
-    if (uuid == null) {
+  public static boolean isA3sEnabled(ServerApi api, @Nullable String orgUuidV4, String orgKey) {
+    if (orgUuidV4 == null) {
       LOG.debug("A3S entitlement check: could not resolve UUID for org '" + orgKey + "' - falling back to standard analysis");
       return false;
     }
-    var config = api.a3sAnalysisApi().getA3sOrgConfig(uuid);
+    var config = api.a3sAnalysisApi().getA3sOrgConfig(orgUuidV4);
     if (config == null) {
       LOG.debug("A3S entitlement check: could not retrieve org config for org '" + orgKey + "' - falling back to standard analysis");
       return false;

--- a/src/test/java/org/sonarsource/sonarqube/mcp/AutoDetectOrganizationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/AutoDetectOrganizationTest.java
@@ -23,6 +23,7 @@ import org.sonarsource.sonarqube.mcp.serverapi.a3s.A3sAnalysisApi;
 import org.sonarsource.sonarqube.mcp.serverapi.organizations.OrganizationsApi;
 import org.sonarsource.sonarqube.mcp.serverapi.sca.ScaApi;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -49,6 +50,17 @@ class AutoDetectOrganizationTest {
     assertThat(mcpClient.listTools()).isNotEmpty();
     // The org-scoped SCA probe proves the auto-detected org was applied to the ServerApi
     assertThat(harness.getMockSonarQubeServer().hasReceivedRequestContaining(ScaApi.FEATURE_ENABLED_PATH + "?organization=" + AUTO_ORG_KEY)).isTrue();
+    assertThat(harness.getMockSonarQubeServer().countRequestsContaining("organizationKey=")).isZero();
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_fail_startup_when_listing_organizations_fails(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(aResponse().withStatus(401)));
+
+    assertThatThrownBy(() -> harness.newClient(CLOUD_WITHOUT_ORG))
+      .hasMessageContaining("Failed to list SonarQube Cloud organizations for the provided token")
+      .hasMessageContaining("Verify the token is valid, or set SONARQUBE_ORG explicitly");
   }
 
   @SonarQubeMcpServerTest

--- a/src/test/java/org/sonarsource/sonarqube/mcp/AutoDetectOrganizationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/AutoDetectOrganizationTest.java
@@ -1,0 +1,93 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp;
+
+import java.util.Map;
+import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTest;
+import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTestHarness;
+import org.sonarsource.sonarqube.mcp.serverapi.a3s.A3sAnalysisApi;
+import org.sonarsource.sonarqube.mcp.serverapi.organizations.OrganizationsApi;
+import org.sonarsource.sonarqube.mcp.serverapi.sca.ScaApi;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AutoDetectOrganizationTest {
+
+  private static final String AUTO_ORG_KEY = "auto-org";
+  private static final String AUTO_ORG_UUID = "00000000-0000-0000-0000-000000000009";
+  private static final Map<String, String> CLOUD_WITHOUT_ORG = Map.of(
+    "SONARQUBE_IS_CLOUD", "true",
+    "SONARQUBE_TOOLSETS", "issues");
+
+  @SonarQubeMcpServerTest
+  void it_should_auto_select_the_single_organization_of_the_token(SonarQubeMcpServerTestHarness harness) {
+    stubOrganizationsList(harness, """
+      [{"id":"id-1","key":"%s","name":"Auto Org","uuidV4":"%s"}]
+      """.formatted(AUTO_ORG_KEY, AUTO_ORG_UUID));
+    stubOrgScopedProbes(harness);
+
+    var mcpClient = harness.newClient(CLOUD_WITHOUT_ORG);
+
+    assertThat(mcpClient.listTools()).isNotEmpty();
+    // The org-scoped SCA probe proves the auto-detected org was applied to the ServerApi
+    assertThat(harness.getMockSonarQubeServer().hasReceivedRequestContaining(ScaApi.FEATURE_ENABLED_PATH + "?organization=" + AUTO_ORG_KEY)).isTrue();
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_fail_startup_when_token_has_no_organization(SonarQubeMcpServerTestHarness harness) {
+    stubOrganizationsList(harness, "[]");
+
+    assertThatThrownBy(() -> harness.newClient(CLOUD_WITHOUT_ORG))
+      .hasMessageContaining("No SonarQube Cloud organization is associated with the provided token");
+  }
+
+  @SonarQubeMcpServerTest
+  void it_should_fail_startup_when_token_has_multiple_organizations(SonarQubeMcpServerTestHarness harness) {
+    stubOrganizationsList(harness, """
+      [
+        {"id":"id-1","key":"org-one","name":"Org One","uuidV4":"%s"},
+        {"id":"id-2","key":"org-two","name":"Org Two","uuidV4":"00000000-0000-0000-0000-000000000002"}
+      ]
+      """.formatted(AUTO_ORG_UUID));
+
+    assertThatThrownBy(() -> harness.newClient(CLOUD_WITHOUT_ORG))
+      .hasMessageContaining("multiple SonarQube Cloud organizations")
+      .hasMessageContaining("org-one")
+      .hasMessageContaining("org-two");
+  }
+
+  private static void stubOrganizationsList(SonarQubeMcpServerTestHarness harness, String jsonBody) {
+    harness.getMockSonarQubeServer().stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(okJson(jsonBody)));
+  }
+
+  private static void stubOrgScopedProbes(SonarQubeMcpServerTestHarness harness) {
+    harness.getMockSonarQubeServer().stubFor(get(urlPathEqualTo(ScaApi.FEATURE_ENABLED_PATH))
+      .willReturn(okJson("""
+        {"enabled":false}
+        """)));
+    harness.getMockSonarQubeServer().stubFor(get(urlPathEqualTo(A3sAnalysisApi.A3S_ORG_CONFIG_PATH + AUTO_ORG_UUID))
+      .willReturn(okJson("""
+        {"id":"%s","enabled":false,"eligible":true}
+        """.formatted(AUTO_ORG_UUID))));
+  }
+
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/AutoDetectOrganizationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/AutoDetectOrganizationTest.java
@@ -39,6 +39,17 @@ class AutoDetectOrganizationTest {
     "SONARQUBE_TOOLSETS", "issues");
 
   @SonarQubeMcpServerTest
+  void it_should_apply_sonarqube_org_to_startup_server_api(SonarQubeMcpServerTestHarness harness) {
+    var mcpClient = harness.newClient(Map.of(
+      "SONARQUBE_ORG", AUTO_ORG_KEY,
+      "SONARQUBE_TOOLSETS", "issues"));
+
+    assertThat(mcpClient.listTools()).isNotEmpty();
+    assertThat(harness.getMockSonarQubeServer().hasReceivedRequestContaining(ScaApi.FEATURE_ENABLED_PATH + "?organization=" + AUTO_ORG_KEY)).isTrue();
+    assertThat(harness.getMockSonarQubeServer().countRequestsContaining(OrganizationsApi.ORGANIZATIONS_PATH + "?excludeEligibility=true")).isZero();
+  }
+
+  @SonarQubeMcpServerTest
   void it_should_auto_select_the_single_organization_of_the_token(SonarQubeMcpServerTestHarness harness) {
     stubOrganizationsList(harness, """
       [{"id":"id-1","key":"%s","name":"Auto Org","uuidV4":"%s"}]

--- a/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
@@ -83,14 +83,12 @@ class McpServerLaunchConfigurationTest {
   }
 
   @Test
-  void should_default_to_sonarcloud_when_token_only_in_stdio_mode(@TempDir Path tempDir) {
+  void should_throw_in_stdio_mode_when_token_only_without_explicit_cloud_signal(@TempDir Path tempDir) {
     var arg = Map.of("STORAGE_PATH", tempDir.toString(), "SONARQUBE_TOKEN", "token");
 
-    var config = new McpServerLaunchConfiguration(arg);
-
-    assertThat(config.isSonarQubeCloud()).isTrue();
-    assertThat(config.getSonarQubeUrl()).isEqualTo("https://sonarcloud.io");
-    assertThat(config.getSonarqubeOrg()).isNull();
+    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("SONARQUBE_URL, SONARQUBE_ORG, or SONARQUBE_IS_CLOUD=true must be set");
   }
 
   @Test
@@ -532,7 +530,7 @@ class McpServerLaunchConfigurationTest {
   }
 
   @Test
-  void should_default_to_sonarcloud_when_stdio_org_and_url_are_both_unresolved_placeholders(@TempDir Path tempDir) {
+  void should_throw_in_stdio_mode_when_org_and_url_are_both_unresolved_placeholders(@TempDir Path tempDir) {
     var arg = Map.of(
       "STORAGE_PATH", tempDir.toString(),
       "SONARQUBE_TOKEN", "token",
@@ -540,11 +538,9 @@ class McpServerLaunchConfigurationTest {
       "SONARQUBE_URL", "${SONARQUBE_URL}"
     );
 
-    var configuration = new McpServerLaunchConfiguration(arg);
-
-    assertThat(configuration.getSonarqubeOrg()).isNull();
-    assertThat(configuration.getSonarQubeUrl()).isEqualTo("https://sonarcloud.io");
-    assertThat(configuration.isSonarQubeCloud()).isTrue();
+    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("SONARQUBE_URL, SONARQUBE_ORG, or SONARQUBE_IS_CLOUD=true must be set");
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
@@ -83,20 +83,20 @@ class McpServerLaunchConfigurationTest {
   }
 
   @Test
-  void should_throw_in_stdio_mode_when_token_only_without_explicit_cloud_signal(@TempDir Path tempDir) {
+  void should_throw_in_stdio_mode_when_token_only_without_url_or_org(@TempDir Path tempDir) {
     var arg = Map.of("STORAGE_PATH", tempDir.toString(), "SONARQUBE_TOKEN", "token");
 
     assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
       .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("SONARQUBE_URL, SONARQUBE_ORG, or SONARQUBE_IS_CLOUD=true must be set");
+      .hasMessageContaining("SONARQUBE_URL or SONARQUBE_ORG must be set");
   }
 
   @Test
-  void should_default_to_sonarcloud_when_only_is_cloud_flag_is_set_in_stdio_mode(@TempDir Path tempDir) {
+  void should_allow_sonarcloud_url_without_org_in_stdio_mode(@TempDir Path tempDir) {
     var arg = Map.of(
       "STORAGE_PATH", tempDir.toString(),
       "SONARQUBE_TOKEN", "token",
-      "SONARQUBE_IS_CLOUD", "true"
+      "SONARQUBE_URL", "https://sonarcloud.io"
     );
 
     var config = new McpServerLaunchConfiguration(arg);
@@ -104,6 +104,19 @@ class McpServerLaunchConfigurationTest {
     assertThat(config.isSonarQubeCloud()).isTrue();
     assertThat(config.getSonarQubeUrl()).isEqualTo("https://sonarcloud.io");
     assertThat(config.getSonarqubeOrg()).isNull();
+  }
+
+  @Test
+  void should_throw_in_stdio_mode_when_only_is_cloud_flag_is_set(@TempDir Path tempDir) {
+    var arg = Map.of(
+      "STORAGE_PATH", tempDir.toString(),
+      "SONARQUBE_TOKEN", "token",
+      "SONARQUBE_IS_CLOUD", "true"
+    );
+
+    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("SONARQUBE_URL or SONARQUBE_ORG must be set");
   }
 
   @Test
@@ -540,7 +553,7 @@ class McpServerLaunchConfigurationTest {
 
     assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
       .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("SONARQUBE_URL, SONARQUBE_ORG, or SONARQUBE_IS_CLOUD=true must be set");
+      .hasMessageContaining("SONARQUBE_URL or SONARQUBE_ORG must be set");
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
@@ -83,26 +83,29 @@ class McpServerLaunchConfigurationTest {
   }
 
   @Test
-  void should_throw_error_in_stdio_mode_when_neither_url_nor_org_is_set(@TempDir Path tempDir) {
+  void should_default_to_sonarcloud_when_token_only_in_stdio_mode(@TempDir Path tempDir) {
     var arg = Map.of("STORAGE_PATH", tempDir.toString(), "SONARQUBE_TOKEN", "token");
 
-    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("SONARQUBE_URL or SONARQUBE_ORG must be set");
+    var config = new McpServerLaunchConfiguration(arg);
+
+    assertThat(config.isSonarQubeCloud()).isTrue();
+    assertThat(config.getSonarQubeUrl()).isEqualTo("https://sonarcloud.io");
+    assertThat(config.getSonarqubeOrg()).isNull();
   }
 
   @Test
-  void should_throw_error_in_stdio_mode_when_only_is_cloud_flag_is_set(@TempDir Path tempDir) {
-    // SONARQUBE_IS_CLOUD alone is not enough in stdio — org resolution is per-request in HTTP only
+  void should_default_to_sonarcloud_when_only_is_cloud_flag_is_set_in_stdio_mode(@TempDir Path tempDir) {
     var arg = Map.of(
       "STORAGE_PATH", tempDir.toString(),
       "SONARQUBE_TOKEN", "token",
       "SONARQUBE_IS_CLOUD", "true"
     );
 
-    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("SONARQUBE_URL or SONARQUBE_ORG must be set");
+    var config = new McpServerLaunchConfiguration(arg);
+
+    assertThat(config.isSonarQubeCloud()).isTrue();
+    assertThat(config.getSonarQubeUrl()).isEqualTo("https://sonarcloud.io");
+    assertThat(config.getSonarqubeOrg()).isNull();
   }
 
   @Test
@@ -529,7 +532,7 @@ class McpServerLaunchConfigurationTest {
   }
 
   @Test
-  void should_throw_when_stdio_org_and_url_are_both_unresolved_placeholders(@TempDir Path tempDir) {
+  void should_default_to_sonarcloud_when_stdio_org_and_url_are_both_unresolved_placeholders(@TempDir Path tempDir) {
     var arg = Map.of(
       "STORAGE_PATH", tempDir.toString(),
       "SONARQUBE_TOKEN", "token",
@@ -537,9 +540,11 @@ class McpServerLaunchConfigurationTest {
       "SONARQUBE_URL", "${SONARQUBE_URL}"
     );
 
-    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("SONARQUBE_URL or SONARQUBE_ORG must be set");
+    var configuration = new McpServerLaunchConfiguration(arg);
+
+    assertThat(configuration.getSonarqubeOrg()).isNull();
+    assertThat(configuration.getSonarQubeUrl()).isEqualTo("https://sonarcloud.io");
+    assertThat(configuration.isSonarQubeCloud()).isTrue();
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarqube/mcp/harness/MockWebServer.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/harness/MockWebServer.java
@@ -63,6 +63,13 @@ public class MockWebServer {
       .anyMatch(event -> event.getRequest().getUrl().contains(urlSubstring));
   }
 
+  public long countRequestsContaining(String urlSubstring) {
+    return mockServer.getServeEvents().getRequests()
+      .stream()
+      .filter(event -> event.getRequest().getUrl().contains(urlSubstring))
+      .count();
+  }
+
   public StubMapping stubFor(MappingBuilder mappingBuilder) {
     return mockServer.stubFor(mappingBuilder);
   }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/harness/MockWebServer.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/harness/MockWebServer.java
@@ -54,9 +54,13 @@ public class MockWebServer {
   }
 
   public boolean hasReceivedInstalledPluginsRequest() {
+    return hasReceivedRequestContaining("/api/plugins/installed");
+  }
+
+  public boolean hasReceivedRequestContaining(String urlSubstring) {
     return mockServer.getServeEvents().getRequests()
       .stream()
-      .anyMatch(event -> event.getRequest().getUrl().contains("/api/plugins/installed"));
+      .anyMatch(event -> event.getRequest().getUrl().contains(urlSubstring));
   }
 
   public StubMapping stubFor(MappingBuilder mappingBuilder) {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/organizations/OrganizationsApiTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/organizations/OrganizationsApiTest.java
@@ -31,6 +31,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OrganizationsApiTest {
@@ -82,6 +83,62 @@ class OrganizationsApiTest {
       .willReturn(aResponse().withStatus(403)));
 
     assertThat(organizationsApi.getOrganizationUuidV4("my-org")).isNull();
+  }
+
+  @Test
+  void it_should_list_all_organizations_the_token_belongs_to() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(jsonResponse("""
+        [
+          {"id":"id-1","key":"org-one","name":"Org One","uuidV4":"550e8400-e29b-41d4-a716-446655440000"},
+          {"id":"id-2","key":"org-two","name":"Org Two","uuidV4":"550e8400-e29b-41d4-a716-446655440001"}
+        ]
+        """, 200)));
+
+    var organizations = organizationsApi.listOrganizations();
+
+    assertThat(organizations)
+      .extracting(OrganizationsApi.Organization::key, OrganizationsApi.Organization::name)
+      .containsExactly(
+        org.assertj.core.api.Assertions.tuple("org-one", "Org One"),
+        org.assertj.core.api.Assertions.tuple("org-two", "Org Two"));
+  }
+
+  @Test
+  void it_should_return_single_organization() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(jsonResponse("""
+        [{"id":"id-1","key":"org-one","name":"Org One","uuidV4":"550e8400-e29b-41d4-a716-446655440000"}]
+        """, 200)));
+
+    assertThat(organizationsApi.listOrganizations())
+      .singleElement()
+      .extracting(OrganizationsApi.Organization::key)
+      .isEqualTo("org-one");
+  }
+
+  @Test
+  void it_should_return_empty_list_when_token_has_no_organizations() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(jsonResponse("[]", 200)));
+
+    assertThat(organizationsApi.listOrganizations()).isEmpty();
+  }
+
+  @Test
+  void it_should_propagate_error_when_listing_organizations_fails() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(aResponse().withStatus(500)));
+
+    assertThatThrownBy(() -> organizationsApi.listOrganizations()).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void it_should_propagate_error_when_listing_organizations_is_unauthorized() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(OrganizationsApi.ORGANIZATIONS_PATH))
+      .willReturn(aResponse().withStatus(401)));
+
+    assertThatThrownBy(() -> organizationsApi.listOrganizations()).isInstanceOf(RuntimeException.class);
   }
 
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Organization Auto-detection:**
  - Added `autoDetectOrganizationIfNeeded` to resolve the organization via the token in stdio mode when `SONARQUBE_ORG` is unset.
  - Added validation to handle cases with zero or multiple organizations, providing actionable error messages.
- **API Changes:**
  - Updated `OrganizationsApi.listOrganizations` to return a `List<Organization>` and propagate HTTP errors.
- **Configuration Updates:**
  - Removed strict validation requiring `SONARQUBE_ORG` in stdio Cloud mode to support automatic detection.
- **Testing:**
  - Added `AutoDetectOrganizationTest` to verify auto-selection logic and error handling.
  - Updated `OrganizationsApiTest` to cover the new listing functionality.


<sub>This will update automatically on new commits.</sub>