### PR TITLE
MCP-523 Allow MCP to configure client certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,8 @@ When using custom certificates, you can modify your MCP configuration to mount t
 }
 ```
 
+> **Note:** Running the server [from a JAR](#build) instead of the container? The volume mount above installs certificates into the container's OS trust store, which the server also reads. If you cannot use the OS trust store — notably on Windows, where it is not consulted — point the JVM at a Java truststore holding the CA certificate: `-Djavax.net.ssl.trustStore=/path/to/truststore.p12 -Djavax.net.ssl.trustStoreType=PKCS12 -Djavax.net.ssl.trustStorePassword=<passphrase>`. It is added on top of the default trusted certificates.
+
 </details>
 
 ### Proxy
@@ -892,6 +894,96 @@ SOCKS5 proxies are supported.
 | `socksProxyPort`          | SOCKS5 proxy port                  | `1080`  | `1080`       |
 | `java.net.socks.username` | SOCKS5 username (if auth required) | —       | `myuser`     |
 | `java.net.socks.password` | SOCKS5 password (if auth required) | —       | `mypassword` |
+
+</details>
+
+### Client Certificate (Mutual TLS)
+
+If your SonarQube Server requires clients to present a certificate during the TLS handshake (mutual TLS), you can provide a PKCS12 keystore by mounting it into the container and passing its location via `JAVA_OPTS`.
+
+<details>
+<summary>Configuration</summary>
+
+#### Using a PKCS12 keystore
+
+Mount your `.p12` or `.pfx` file into the container and set the `JAVA_OPTS` environment variable with the keystore properties:
+
+```bash
+docker run --init --pull=always -i --rm \
+  -v /path/to/client.p12:/etc/ssl/mcp/client.p12:ro \
+  -e JAVA_OPTS="-Djavax.net.ssl.keyStore=/etc/ssl/mcp/client.p12 -Djavax.net.ssl.keyStoreType=PKCS12 -Djavax.net.ssl.keyStorePassword=<passphrase>" \
+  -e SONARQUBE_TOKEN="<token>" \
+  -e SONARQUBE_URL="<url>" \
+  sonarsource/sonarqube-mcp
+```
+
+> **Note:** The certificate file must be readable by the container process. Check and fix permissions if needed:
+> ```bash
+> ls -la /path/to/client.p12       # look for -rw-r--r-- (644) or wider
+> chmod 644 /path/to/client.p12    # grant read access to the container user
+> ```
+
+Omit `-Djavax.net.ssl.keyStorePassword` if the keystore has no passphrase. Note that the passphrase used here would be visible through `docker inspect` or process list.
+
+#### MCP Configuration with a Client Certificate
+
+```json
+{
+  "sonarqube": {
+    "command": "docker",
+    "args": [
+      "run", "--init", "--pull=always", "-i", "--rm",
+      "-v", "/path/to/client.p12:/etc/ssl/mcp/client.p12:ro",
+      "-e", "JAVA_OPTS",
+      "-e", "SONARQUBE_TOKEN",
+      "-e", "SONARQUBE_URL",
+      "sonarsource/sonarqube-mcp"
+    ],
+    "env": {
+      "JAVA_OPTS": "-Djavax.net.ssl.keyStore=/etc/ssl/mcp/client.p12 -Djavax.net.ssl.keyStoreType=PKCS12 -Djavax.net.ssl.keyStorePassword=<passphrase>",
+      "SONARQUBE_TOKEN": "<token>",
+      "SONARQUBE_URL": "<url>"
+    }
+  }
+}
+```
+
+#### Using a PKCS12 keystore with a standalone JAR
+
+When running the server [from a JAR](#build), pass the keystore properties as JVM arguments before `-jar`:
+
+```bash
+java \
+  -Djavax.net.ssl.keyStore=/path/to/client.p12 \
+  -Djavax.net.ssl.keyStoreType=PKCS12 \
+  -Djavax.net.ssl.keyStorePassword=<passphrase> \
+  -jar <path_to_sonarqube_mcp_server_jar>
+```
+
+Omit `-Djavax.net.ssl.keyStorePassword` if the keystore has no passphrase.
+
+#### MCP Configuration with a Client Certificate (JAR)
+
+```json
+{
+  "sonarqube": {
+    "command": "java",
+    "args": [
+      "-Djavax.net.ssl.keyStore=/path/to/client.p12",
+      "-Djavax.net.ssl.keyStoreType=PKCS12",
+      "-Djavax.net.ssl.keyStorePassword=<passphrase>",
+      "-jar",
+      "<path_to_sonarqube_mcp_server_jar>"
+    ],
+    "env": {
+      "SONARQUBE_TOKEN": "<token>",
+      "SONARQUBE_URL": "<url>"
+    }
+  }
+}
+```
+
+> **Note:** PEM certificate and key files (separate `.crt`/`.key` files) must be converted to PKCS12 format first. Use `openssl pkcs12 -export -in client.crt -inkey client.key -out client.p12` to convert them.
 
 </details>
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -9,4 +9,4 @@ set -e
 # - Makes Java PID 1, so it directly receives SIGTERM from Docker
 # - Ensures the shutdown hook in SonarQubeMcpServer.java runs on container stop
 # - Without exec, the shell stays as PID 1 and may not forward signals properly
-exec java -jar /app/sonarqube-mcp-server.jar
+exec java ${JAVA_OPTS:-} -jar /app/sonarqube-mcp-server.jar

--- a/src/main/java/org/sonarsource/sonarqube/mcp/http/HttpClientProvider.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/http/HttpClientProvider.java
@@ -45,12 +45,17 @@ public class HttpClientProvider {
     this.userAgent = userAgent;
     var sslFactoryBuilder = SSLFactory.builder()
       .withDefaultTrustMaterial();
+    if (isClientCertificateConfigured()) {
+      applySslMaterial("Could not load the configured client certificate, proceeding without it",
+        sslFactoryBuilder::withSystemPropertyDerivedIdentityMaterial);
+    }
     if (!SystemUtils.IS_OS_WINDOWS) {
-      try {
-        sslFactoryBuilder.withSystemTrustMaterial();
-      } catch (Exception e) {
-        LOG.warn("Could not load system trust material, falling back to JDK defaults: " + e.getMessage());
-      }
+      applySslMaterial("Could not load system trust material, falling back to JDK defaults",
+        sslFactoryBuilder::withSystemTrustMaterial);
+    }
+    if (isCustomTrustStoreConfigured()) {
+      applySslMaterial("Could not load the configured trust store, falling back to defaults",
+        sslFactoryBuilder::withSystemPropertyDerivedTrustMaterial);
     }
     var sslFactory = sslFactoryBuilder.build();
     var sslContext = sslFactory.getSslContext();
@@ -83,6 +88,24 @@ public class HttpClientProvider {
     this.httpClient = httpClientBuilder.build();
 
     httpClient.start();
+  }
+
+  private static boolean isClientCertificateConfigured() {
+    var keyStore = System.getProperty("javax.net.ssl.keyStore");
+    return keyStore != null && !keyStore.isBlank();
+  }
+
+  private static boolean isCustomTrustStoreConfigured() {
+    var trustStore = System.getProperty("javax.net.ssl.trustStore");
+    return trustStore != null && !trustStore.isBlank();
+  }
+
+  private static void applySslMaterial(String failureMessage, Runnable materialLoader) {
+    try {
+      materialLoader.run();
+    } catch (Exception e) {
+      LOG.warn(failureMessage + ": " + e.getMessage());
+    }
   }
 
   private static IOReactorConfig buildSocksProxyConfig() {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/http/HttpClientProviderClientCertificateTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/http/HttpClientProviderClientCertificateTests.java
@@ -1,0 +1,175 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.http;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.LoggerFactory;
+import org.sonarsource.sonarqube.mcp.log.McpLogger;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HttpClientProviderClientCertificateTests {
+
+  private static final String USER_AGENT = "SonarQube MCP Server Tests";
+  private static final String KEY_STORE_PROPERTY = "javax.net.ssl.keyStore";
+  private static final String KEY_STORE_PASSWORD_PROPERTY = "javax.net.ssl.keyStorePassword";
+  private static final String TRUST_STORE_PROPERTY = "javax.net.ssl.trustStore";
+  private static final String TRUST_STORE_PASSWORD_PROPERTY = "javax.net.ssl.trustStorePassword";
+  private static final String KEY_STORE_PASSWORD = "test123";
+  private static final Path KEYSTORE_PATH = resolveKeystorePath();
+
+  @RegisterExtension
+  static WireMockExtension sonarqubeMock = WireMockExtension.newInstance()
+    .options(wireMockConfig()
+      .httpDisabled(true)
+      .dynamicHttpsPort()
+      .keystorePath(KEYSTORE_PATH.toString())
+      .keystorePassword(KEY_STORE_PASSWORD)
+      .keyManagerPassword(KEY_STORE_PASSWORD)
+      .needClientAuth(true)
+      .trustStorePath(KEYSTORE_PATH.toString())
+      .trustStorePassword(KEY_STORE_PASSWORD))
+    .build();
+
+  private String originalKeyStore;
+  private String originalKeyStorePassword;
+  private String originalTrustStore;
+  private String originalTrustStorePassword;
+  private HttpClientProvider underTest;
+  private Logger mcpLogger;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void setUp() {
+    originalKeyStore = System.getProperty(KEY_STORE_PROPERTY);
+    originalKeyStorePassword = System.getProperty(KEY_STORE_PASSWORD_PROPERTY);
+    originalTrustStore = System.getProperty(TRUST_STORE_PROPERTY);
+    originalTrustStorePassword = System.getProperty(TRUST_STORE_PASSWORD_PROPERTY);
+    mcpLogger = (Logger) LoggerFactory.getLogger(McpLogger.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    mcpLogger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (underTest != null) {
+      underTest.shutdown();
+    }
+    mcpLogger.detachAppender(logAppender);
+    logAppender.stop();
+    restoreProperty(KEY_STORE_PROPERTY, originalKeyStore);
+    restoreProperty(KEY_STORE_PASSWORD_PROPERTY, originalKeyStorePassword);
+    restoreProperty(TRUST_STORE_PROPERTY, originalTrustStore);
+    restoreProperty(TRUST_STORE_PASSWORD_PROPERTY, originalTrustStorePassword);
+  }
+
+  private static void restoreProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+  @Test
+  void it_should_present_client_certificate_when_keystore_configured() {
+    trustServerCertificate();
+    System.setProperty(KEY_STORE_PROPERTY, KEYSTORE_PATH.toString());
+    System.setProperty(KEY_STORE_PASSWORD_PROPERTY, KEY_STORE_PASSWORD);
+
+    underTest = new HttpClientProvider(USER_AGENT);
+
+    try (var ignored = underTest.getHttpClient("token").getAsync(mcpUrl("/test")).join()) {
+      // nothing
+    }
+    sonarqubeMock.verify(getRequestedFor(urlEqualTo("/test")));
+  }
+
+  @Test
+  void it_should_fail_handshake_when_client_certificate_is_absent() {
+    trustServerCertificate();
+    System.clearProperty(KEY_STORE_PROPERTY);
+    System.clearProperty(KEY_STORE_PASSWORD_PROPERTY);
+
+    underTest = new HttpClientProvider(USER_AGENT);
+    var getRequest = underTest.getHttpClient("token").getAsync(mcpUrl("/test"));
+    assertThatThrownBy(getRequest::join)
+      .isInstanceOf(CompletionException.class)
+      .hasCauseInstanceOf(IOException.class);
+  }
+
+  @Test
+  void it_should_warn_and_continue_when_keystore_property_points_to_invalid_keystore() {
+    System.setProperty(KEY_STORE_PROPERTY, "/tmp/non-existent-keystore.p12");
+
+    underTest = new HttpClientProvider(USER_AGENT);
+
+    assertThat(logAppender.list)
+      .filteredOn(event -> event.getLevel() == Level.WARN)
+      .extracting(ILoggingEvent::getFormattedMessage)
+      .anyMatch(message -> message.contains("client certificate"));
+  }
+
+  @Test
+  void it_should_warn_and_continue_when_truststore_property_points_to_invalid_truststore() {
+    System.setProperty(TRUST_STORE_PROPERTY, "/tmp/non-existent-truststore.p12");
+
+    underTest = new HttpClientProvider(USER_AGENT);
+
+    assertThat(logAppender.list)
+      .filteredOn(event -> event.getLevel() == Level.WARN)
+      .extracting(ILoggingEvent::getFormattedMessage)
+      .anyMatch(message -> message.contains("trust store"));
+  }
+
+  private static void trustServerCertificate() {
+    System.setProperty(TRUST_STORE_PROPERTY, KEYSTORE_PATH.toString());
+    System.setProperty(TRUST_STORE_PASSWORD_PROPERTY, KEY_STORE_PASSWORD);
+  }
+
+  private static String mcpUrl(String path) {
+    return sonarqubeMock.getRuntimeInfo().getHttpsBaseUrl() + path;
+  }
+
+  private static Path resolveKeystorePath() {
+    try {
+      return Paths.get(Objects.requireNonNull(
+        HttpClientProviderClientCertificateTests.class.getResource("/ssl/test-keystore.p12")).toURI());
+    } catch (Exception e) {
+      throw new IllegalStateException("Test keystore not found at /ssl/test-keystore.p12", e);
+    }
+  }
+
+}

--- a/src/test/resources/ssl/README.md
+++ b/src/test/resources/ssl/README.md
@@ -34,5 +34,7 @@ keytool -genkeypair \
 
 The keystore is used in `HttpsServerTransportIntegrationTest` to test HTTPS server startup and SSL configuration without requiring manual certificate generation for each test run.
 
+It is also used in `HttpClientProviderClientCertificateTests`, both as the client identity material and — since a PKCS12 key entry's leaf certificate doubles as a trust anchor — as the truststore for the mutual-TLS WireMock server (client and server share the same `CN=localhost` certificate).
+
 **Note**: These certificates are for testing only and should never be used in production.
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Security/TLS Configuration:**
  - Updated `HttpClientProvider` to support client certificate authentication using system properties `javax.net.ssl.keyStore` and `trustStore`.
  - Modified `docker-entrypoint.sh` to propagate `JAVA_OPTS` to the running JVM instance.
- **Testing:**
  - Added `HttpClientProviderClientCertificateTests` to verify mTLS handshake scenarios and invalid keystore handling.
- **Documentation:**
  - Added comprehensive mTLS configuration guide to `README.md` for both Docker and standalone JAR deployments.
  - Updated `src/test/resources/ssl/README.md` to clarify the dual usage of test certificates in mTLS scenarios.

<sub>This will update automatically on new commits.</sub>