### PR TITLE
CAG-757 Gate CAG loading on hasEntitlement instead of allowed

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -490,10 +490,11 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       LOG.debug("CAG entitlement check: could not retrieve entitlement for org '" + orgKey + "' - skipping CAG");
       return false;
     }
-    if (!entitlement.allowed()) {
+    if (!entitlement.hasEntitlement()) {
       LOG.debug("CAG entitlement check: org '" + orgKey + "' is not entitled to use CAG");
+      return false;
     }
-    return entitlement.allowed();
+    return true;
   }
 
   @Nullable

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApi.java
@@ -44,6 +44,6 @@ public class CagApi {
     }
   }
 
-  public record CagEntitlementResponse(boolean allowed) {
+  public record CagEntitlementResponse(boolean hasEntitlement) {
   }
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/harness/SonarQubeMcpServerTestHarness.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/harness/SonarQubeMcpServerTestHarness.java
@@ -295,11 +295,11 @@ public class SonarQubeMcpServerTestHarness extends TypeBasedParameterResolver<So
             """.formatted(orgUuidV4))));
       }
 
-      // Stub CAG entitlement API — denied by default; tests that need CAG should call stubCagEntitlement(true)
+      // Stub CAG entitlement API — not entitled by default; tests that need CAG should call stubCagEntitlement(true)
       if (!mockSonarQubeServer.isStubConfigured(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)) {
         mockSonarQubeServer.stubFor(get(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
           .willReturn(okJson("""
-            {"allowed":false}
+            {"hasEntitlement":false}
             """)));
       }
 
@@ -330,15 +330,15 @@ public class SonarQubeMcpServerTestHarness extends TypeBasedParameterResolver<So
   }
 
   /**
-   * Stub CAG entitlement API to allow/deny CAG for the organization.
-   * Must be called before prepareMockWebServer() to override the default (disabled) stub.
+   * Stub CAG entitlement API for the organization.
+   * Must be called before prepareMockWebServer() to override the default (not-entitled) stub.
    */
-  public void stubCagEntitlement(boolean allowed) {
+  public void stubCagEntitlement(boolean hasEntitlement) {
     var orgUuidV4 = "00000000-0000-0000-0000-000000000001";
     mockSonarQubeServer.stubFor(get(CagApi.CAG_ENTITLEMENT_PATH + orgUuidV4)
       .willReturn(okJson("""
-        {"allowed":%b}
-        """.formatted(allowed))));
+        {"hasEntitlement":%b}
+        """.formatted(hasEntitlement))));
   }
 
   /**

--- a/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApiTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/serverapi/cag/CagApiTest.java
@@ -53,7 +53,46 @@ class CagApiTest {
   }
 
   @Test
-  void it_should_return_cag_entitlement_when_org_is_allowed() {
+  void it_should_return_cag_entitlement_when_org_is_entitled() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
+      .willReturn(jsonResponse("""
+        {"hasEntitlement":true}
+        """, 200)));
+
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
+
+    assertThat(entitlement).isNotNull();
+    assertThat(entitlement.hasEntitlement()).isTrue();
+  }
+
+  @Test
+  void it_should_return_cag_entitlement_when_org_is_not_entitled() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
+      .willReturn(jsonResponse("""
+        {"hasEntitlement":false}
+        """, 200)));
+
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
+
+    assertThat(entitlement).isNotNull();
+    assertThat(entitlement.hasEntitlement()).isFalse();
+  }
+
+  @Test
+  void it_should_return_has_entitlement_true_when_consumption_limit_reached() {
+    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
+      .willReturn(jsonResponse("""
+        {"allowed":false,"hasEntitlement":true,"consumption":{"consumed":1000,"limit":1000}}
+        """, 200)));
+
+    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
+
+    assertThat(entitlement).isNotNull();
+    assertThat(entitlement.hasEntitlement()).isTrue();
+  }
+
+  @Test
+  void it_should_default_has_entitlement_to_false_when_field_is_absent() {
     sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
       .willReturn(jsonResponse("""
         {"allowed":true}
@@ -62,33 +101,7 @@ class CagApiTest {
     var entitlement = cagApi.getCagEntitlement(ORG_UUID);
 
     assertThat(entitlement).isNotNull();
-    assertThat(entitlement.allowed()).isTrue();
-  }
-
-  @Test
-  void it_should_return_cag_entitlement_when_org_is_denied() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
-      .willReturn(jsonResponse("""
-        {"allowed":false}
-        """, 200)));
-
-    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
-
-    assertThat(entitlement).isNotNull();
-    assertThat(entitlement.allowed()).isFalse();
-  }
-
-  @Test
-  void it_should_ignore_cag_entitlement_consumption() {
-    sonarqubeMock.stubFor(get(urlPathEqualTo(CAG_ENTITLEMENT_PUBLIC_PATH))
-      .willReturn(jsonResponse("""
-        {"allowed":true,"consumption":{"consumed":500,"limit":1000}}
-        """, 200)));
-
-    var entitlement = cagApi.getCagEntitlement(ORG_UUID);
-
-    assertThat(entitlement).isNotNull();
-    assertThat(entitlement.allowed()).isTrue();
+    assertThat(entitlement.hasEntitlement()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Validation

A temporary docker image with the changes from this PR and the changes included in https://github.com/SonarSource/sonar-context-augmentation/pull/331
was created here: https://github.com/SonarSource/sonar-context-augmentation/actions/runs/29572045062

The temporary SQ MCP server docker image was used in Cursor to validate the different scenarios:

1) No CAG entitlement -> CAG tools are not displayed ✅ 
<img width="1062" height="1078" alt="Screenshot 2026-07-17 150214" src="https://github.com/user-attachments/assets/6d8a79b8-e871-4b31-a9de-4861fa5fdb18" />

2) CAG Entitlement + consumption limit not reached -> all tools displayed + tool invocation succeed ✅ 
<img width="1638" height="1088" alt="Screenshot 2026-07-17 145801" src="https://github.com/user-attachments/assets/73f443a1-e722-4eb8-9fc6-3ec38ab5df72" />

3) CAG entitlement + consumption limit reached -> all tools displayed + tool invocation fail with limit reached message ✅ 
<img width="1676" height="1085" alt="Screenshot 2026-07-17 150009" src="https://github.com/user-attachments/assets/8360af7f-c7de-407e-b170-92719f48a9d2" />

----
## Summary by Gitar

- **Refactored entitlement logic:**
    - Switched CAG loading validation from `allowed()` to `hasEntitlement()` in `SonarQubeMcpServer.java`.
    - Updated `CagEntitlementResponse` record in `CagApi.java` to use `hasEntitlement` field.
- **Updated test infrastructure:**
    - Adjusted `SonarQubeMcpServerTestHarness.java` to use `hasEntitlement` for default and stubbed CAG responses.
    - Refactored `CagApiTest.java` to reflect the new entitlement check logic and verify specific behavior when consumption limits are reached or fields are missing.


<sub>This will update automatically on new commits.</sub>