### PR TITLE
MCP-561 Update CAG to version 0.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.17.0.2614
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.18.0.2833
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.23-SNAPSHOT
-sonarContextAugmentationVersion=0.17.0.2614
+sonarContextAugmentationVersion=0.18.0.2833
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true


### PR DESCRIPTION
 - Expose CAG MCP tools in case of over-consumption, see CAG-753
 - Minor vortex-related changes
----
## Summary by Gitar

- **Dependency updates:**
    - Upgraded `sonarContextAugmentationVersion` to `0.18.0.2833` in `gradle.properties` and `Dockerfile`.

<sub>This will update automatically on new commits.</sub>