### PR TITLE
MCP-564 Changed the slack channel for freeze/unfreeze notifications

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -79,7 +79,7 @@ jobs:
       project-name: "SonarQube MCP Server"
       short-description: ${{ inputs.short-description }}
       branch: ${{ inputs.branch }}
-      slack-channel: "C02E6L5C01H"
+      slack-channel: "C06JQ30RV88" #squad-ide-slcore-bots
       is-test-run: ${{ inputs.dry-run }}
       new-version: ${{ inputs.new-version }}
 


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
    - Updated `slack-channel` ID in `.github/workflows/full-release.yml` from `C02E6L5C01H` to `C06JQ30RV88` for freeze/unfreeze notifications.

<sub>This will update automatically on new commits.</sub>