### PR TITLE
MCP-566 Set organization for Docker smoke test in cloud mode

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,6 +103,7 @@ jobs:
             -e SONARQUBE_IS_CLOUD=true \
             -e SONARQUBE_URL=https://sonarcloud.io \
             -e SONARQUBE_TOKEN=smoke-test \
+            -e SONARQUBE_ORG=smoke-test-org \
             -e TELEMETRY_DISABLED=true \
             ${{ needs.prepare.outputs.temp_image }})
 


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
    - Added `SONARQUBE_ORG` environment variable to the Docker smoke test job in `.github/workflows/docker-publish.yml`.

<sub>This will update automatically on new commits.</sub>