### PR TITLE
MCP-579 Bump CAG to 0.19.0.3620

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.18.0.2833
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.19.0.3620
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.24-SNAPSHOT
-sonarContextAugmentationVersion=0.18.0.2833
+sonarContextAugmentationVersion=0.19.0.3620
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true


### PR DESCRIPTION
## Summary
- Bump `sonarContextAugmentationVersion` from `0.18.0.2833` to `0.19.0.3620` in `gradle.properties`
- Keep Dockerfile `SONAR_CONTEXT_AUGMENTATION_VERSION` ARG in sync

Consistency bump after CAG 0.19.0.3620 release. Most user-facing 0.19 changes are CLI/hooks; MCP pin update avoids version drift.

Jira: https://sonarsource.atlassian.net/browse/MCP-578

## Test plan
- [ ] CI green
- [ ] Confirm both pins are `0.19.0.3620`