### PR TITLE
feat: make background initialization timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,12 @@ To enable full functionality, the following environment variables must be set be
 
 > 💡 **Configuration Tip (stdio mode)**: The presence of `SONARQUBE_ORG` determines whether you're connecting to SonarQube Cloud or Server. If `SONARQUBE_ORG` is set, SonarQube Cloud is used; otherwise, SonarQube Server is used.
 
+#### Startup and shutdown
+
+| Environment variable             | Description                                                                                                                                                    | Default |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `SONARQUBE_INIT_TIMEOUT_SECONDS` | How long shutdown waits for background initialization (analyzer downloads) to finish. Raise it on slow or high-latency connections where analyzers time out. | `30`    |
+
 ### Transport Modes
 
 The [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) defines two transport mechanisms: **Stdio** and **Streamable HTTP**. The SonarQube MCP Server supports both:

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -811,11 +811,13 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     if (initializationFuture.isDone()) {
       return;
     }
+    var timeoutSeconds = mcpConfiguration.getInitTimeoutSeconds();
     LOG.info("Waiting for background initialization to complete before shutdown...");
     try {
-      initializationFuture.get(30, TimeUnit.SECONDS);
+      initializationFuture.get(timeoutSeconds, TimeUnit.SECONDS);
     } catch (TimeoutException | ExecutionException e) {
-      LOG.warn("Background initialization did not complete within 30 seconds, proceeding with shutdown");
+      LOG.warn("Background initialization did not complete within " + timeoutSeconds
+        + " seconds, proceeding with shutdown. Set SONARQUBE_INIT_TIMEOUT_SECONDS to allow more time.");
       initializationFuture.cancel(true);
     } catch (Exception e) {
       LOG.error("Background initialization failed or was interrupted", e);

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -95,6 +95,10 @@ public class McpServerLaunchConfiguration {
 
   private static final String SONARQUBE_MCP_IN_CONTAINER = "SONARQUBE_MCP_IN_CONTAINER";
 
+  // Shutdown configuration
+  private static final String SONARQUBE_INIT_TIMEOUT_SECONDS = "SONARQUBE_INIT_TIMEOUT_SECONDS";
+  private static final int DEFAULT_INIT_TIMEOUT_SECONDS = 30;
+
   private final Path storagePath;
   private final String hostMachineAddress;
   private final String sonarqubeUrl;
@@ -109,7 +113,8 @@ public class McpServerLaunchConfiguration {
   private final String userAgent;
   private final boolean isTelemetryEnabled;
   private final boolean isSonarQubeCloud;
-  
+  private final int initTimeoutSeconds;
+
   // HTTP transport configuration
   private final boolean isHttpEnabled;
   private final int httpPort;
@@ -185,6 +190,9 @@ public class McpServerLaunchConfiguration {
     this.userAgent = APP_NAME + " " + appVersion;
     this.isTelemetryEnabled = !Boolean.parseBoolean(getValueViaEnvOrPropertyOrDefault(environment, TELEMETRY_DISABLED, "false"));
     
+    this.initTimeoutSeconds = parseInitTimeoutSecondsValue(
+      getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_INIT_TIMEOUT_SECONDS, String.valueOf(DEFAULT_INIT_TIMEOUT_SECONDS)));
+
     this.httpPort = parseHttpPortValue(getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_HTTP_PORT, "8080"));
     this.httpHost = getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_HTTP_HOST, "127.0.0.1");
 
@@ -292,6 +300,14 @@ public class McpServerLaunchConfiguration {
     return httpPort;
   }
 
+  /**
+   * How long shutdown waits for background initialization (analyzer downloads) to finish.
+   * Configurable because slow or high-latency environments need more than the default.
+   */
+  public int getInitTimeoutSeconds() {
+    return initTimeoutSeconds;
+  }
+
   public String getHttpHost() {
     return httpHost;
   }
@@ -383,6 +399,21 @@ public class McpServerLaunchConfiguration {
       return port;
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("Invalid SONARQUBE_IDE_PORT value: " + portStr, e);
+    }
+  }
+
+  private static int parseInitTimeoutSecondsValue(@Nullable String timeoutStr) {
+    if (isNullOrBlank(timeoutStr)) {
+      return DEFAULT_INIT_TIMEOUT_SECONDS;
+    }
+    try {
+      var timeout = Integer.parseInt(timeoutStr);
+      if (timeout < 1) {
+        throw new IllegalArgumentException("SONARQUBE_INIT_TIMEOUT_SECONDS value must be a positive number of seconds, got: " + timeout);
+      }
+      return timeout;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid SONARQUBE_INIT_TIMEOUT_SECONDS value: " + timeoutStr, e);
     }
   }
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationTest.java
@@ -569,4 +569,59 @@ class McpServerLaunchConfigurationTest {
       .hasMessageContaining("SONARQUBE_TOKEN environment variable or property must be set");
   }
 
+  @Test
+  void should_default_init_timeout_to_30_seconds(@TempDir Path tempDir) {
+    var config = new McpServerLaunchConfiguration(minimalEnvironment(tempDir));
+
+    assertThat(config.getInitTimeoutSeconds()).isEqualTo(30);
+  }
+
+  @Test
+  void should_use_configured_init_timeout(@TempDir Path tempDir) {
+    var arg = new java.util.HashMap<>(minimalEnvironment(tempDir));
+    arg.put("SONARQUBE_INIT_TIMEOUT_SECONDS", "180");
+
+    var config = new McpServerLaunchConfiguration(arg);
+
+    assertThat(config.getInitTimeoutSeconds()).isEqualTo(180);
+  }
+
+  @Test
+  void should_fall_back_to_default_when_init_timeout_is_blank(@TempDir Path tempDir) {
+    var arg = new java.util.HashMap<>(minimalEnvironment(tempDir));
+    arg.put("SONARQUBE_INIT_TIMEOUT_SECONDS", "   ");
+
+    var config = new McpServerLaunchConfiguration(arg);
+
+    assertThat(config.getInitTimeoutSeconds()).isEqualTo(30);
+  }
+
+  @Test
+  void should_reject_non_numeric_init_timeout(@TempDir Path tempDir) {
+    var arg = new java.util.HashMap<>(minimalEnvironment(tempDir));
+    arg.put("SONARQUBE_INIT_TIMEOUT_SECONDS", "not-a-number");
+
+    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid SONARQUBE_INIT_TIMEOUT_SECONDS value: not-a-number");
+  }
+
+  @Test
+  void should_reject_non_positive_init_timeout(@TempDir Path tempDir) {
+    var arg = new java.util.HashMap<>(minimalEnvironment(tempDir));
+    arg.put("SONARQUBE_INIT_TIMEOUT_SECONDS", "0");
+
+    assertThatThrownBy(() -> new McpServerLaunchConfiguration(arg))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("must be a positive number of seconds");
+  }
+
+  private static Map<String, String> minimalEnvironment(Path tempDir) {
+    return Map.of(
+      "STORAGE_PATH", tempDir.toString(),
+      "SONARQUBE_TOKEN", "test-token",
+      "SONARQUBE_URL", "https://test-sonarqube-server.com"
+    );
+  }
+
 }


### PR DESCRIPTION
Closes #508

## Problem

On a high-latency connection the container shuts down before it has finished downloading its analyzers. `awaitBackgroundInitialization()` waits a hardcoded 30 seconds, then cancels the future, and the remaining plugin downloads fail:

```
WARN  Background initialization did not complete within 30 seconds, proceeding with shutdown
ERROR Failed to download plugin 'java'
```

## Change

Adds `SONARQUBE_INIT_TIMEOUT_SECONDS`, defaulting to 30, so behaviour is unchanged when it is not set.

Two deliberate choices, both open to discussion:

**Naming.** @elegier suggested `MCP_INIT_TIMEOUT`. I used `SONARQUBE_INIT_TIMEOUT_SECONDS` instead, to match the `SONARQUBE_*` convention every other variable in `McpServerLaunchConfiguration` follows, and to put the unit in the name rather than leave it implicit. Happy to rename if you prefer the original.

**Not the alternative.** The issue also floated removing the timeout entirely and letting download failures drive shutdown. I did not do that — an unbounded wait on a shutdown path can hang a container indefinitely, which is a worse failure than a slow start.

Parsing mirrors the existing `parseHttpPortValue`: blank falls back to the default, non-numeric and non-positive values fail fast with an explicit message.

The warning itself said "within 30 seconds" regardless of the configured value, so it now reports the real timeout and names the variable to raise.

`README.md` documents the variable in a short "Startup and shutdown" table, placed before "Transport Modes" since it is not transport-specific.

## Tests

Five tests added to `McpServerLaunchConfigurationTest`: default, explicit value, blank falls back to default, non-numeric rejected, non-positive rejected.

## ⚠️ I could not run your build, and I think that is worth reporting on its own

`./gradlew build` fails for anyone outside SonarSource. `build.gradle.kts` falls back to `mavenCentral()` when Artifactory credentials are absent, but the pinned `sonarlint-core` artifacts are not there:

- `org.sonarsource.sonarlint.core:sonarlint-core:11.8.0.86062` → **404** on Maven Central (it only publishes up to `10.24.0.81415`)
- the same coordinates on `repox.jfrog.io` → **401**

So an external contributor cannot compile or test this repository at all. That is a real barrier to the outside contributions the `good first issue` and `help wanted` labels invite.

What I did instead: extracted `parseInitTimeoutSecondsValue` verbatim into a standalone file and ran it under Java 21 (the toolchain version this project targets) across all seven cases — default from null, default from blank, explicit value, lower bound of 1, non-numeric, zero, negative. All seven behave as intended. That validates the parsing logic, **not** the integration, so please let CI be the judge on the wiring.

I would rather flag this than quietly present the change as fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
