### PR TITLE
MCP-576 Support multiple ToolCategory per tool

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -598,7 +598,7 @@ public class SonarQubeMcpServer implements ServerApiProvider {
 
   private List<Tool> filterForEnabledTools(List<Tool> toolsToFilter) {
     return toolsToFilter.stream()
-      .filter(tool -> mcpConfiguration.isToolCategoryEnabled(tool.getCategory()))
+      .filter(tool -> tool.getCategories().stream().anyMatch(mcpConfiguration::isToolCategoryEnabled))
       .filter(tool -> !mcpConfiguration.isReadOnlyMode() || tool.definition().annotations().readOnlyHint())
       .toList();
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/Tool.java
@@ -25,24 +25,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarqube.mcp.tools.exception.MissingRequiredArgumentException;
 
 public abstract class Tool {
   private final McpSchema.Tool definition;
-  private final ToolCategory category;
+  private final Set<ToolCategory> categories;
 
-  protected Tool(McpSchema.Tool definition, ToolCategory category) {
+  protected Tool(McpSchema.Tool definition, ToolCategory... categories) {
     this.definition = definition;
-    this.category = category;
+    this.categories = Set.of(categories);
   }
 
   public McpSchema.Tool definition() {
     return definition;
   }
 
-  public ToolCategory getCategory() {
-    return category;
+  public Set<ToolCategory> getCategories() {
+    return categories;
   }
 
   /**

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/ToolCategory.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/ToolCategory.java
@@ -25,7 +25,7 @@ import jakarta.annotation.Nullable;
 
 /**
  * Categories of tools that can be selectively enabled or disabled.
- * Each tool belongs to exactly one category.
+ * A tool may belong to one or more categories.
  */
 public enum ToolCategory {
   ANALYSIS("analysis"),

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/PerRequestToolFilteringHandler.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/PerRequestToolFilteringHandler.java
@@ -136,13 +136,13 @@ public class PerRequestToolFilteringHandler implements McpStatelessServerHandler
   }
 
   private static boolean isCategoryAllowed(Tool tool, @Nullable Set<ToolCategory> allowedCategories) {
-    if (tool.getCategory() == ToolCategory.PROJECTS) {
+    if (tool.getCategories().contains(ToolCategory.PROJECTS)) {
       return true;
     }
     if (allowedCategories == null) {
       return true;
     }
-    return allowedCategories.contains(tool.getCategory());
+    return tool.getCategories().stream().anyMatch(allowedCategories::contains);
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerGenericTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerGenericTest.java
@@ -553,7 +553,7 @@ class SonarQubeMcpServerGenericTest {
 
     var config = server.getMcpConfiguration();
     var enabledToolNames = server.getSupportedTools().stream()
-      .filter(tool -> config.isToolCategoryEnabled(tool.getCategory()))
+      .filter(tool -> tool.getCategories().stream().anyMatch(config::isToolCategoryEnabled))
       .map(tool -> tool.definition().name())
       .toList();
     assertThat(enabledToolNames)
@@ -584,7 +584,7 @@ class SonarQubeMcpServerGenericTest {
 
     var config = server.getMcpConfiguration();
     var enabledToolNames = server.getSupportedTools().stream()
-      .filter(tool -> config.isToolCategoryEnabled(tool.getCategory()))
+      .filter(tool -> tool.getCategories().stream().anyMatch(config::isToolCategoryEnabled))
       .map(tool -> tool.definition().name())
       .toList();
     assertThat(enabledToolNames)

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedMcpToolTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedMcpToolTest.java
@@ -72,7 +72,7 @@ class ProxiedMcpToolTest {
   void getCategory_should_return_cag() {
     var tool = new ProxiedMcpTool("weather", "get_weather", originalTool, clientManager);
 
-    assertThat(tool.getCategory()).isEqualTo(ToolCategory.CAG);
+    assertThat(tool.getCategories()).containsExactly(ToolCategory.CAG);
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderMediumTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/ProxiedToolsLoaderMediumTest.java
@@ -131,7 +131,7 @@ class ProxiedToolsLoaderMediumTest {
 
     assertThat(tools)
       .isNotEmpty()
-      .allMatch(t -> t.getCategory() == ToolCategory.CAG)
+      .allMatch(t -> t.getCategories().equals(Set.of(ToolCategory.CAG)))
       .allMatch(ProxiedMcpTool.class::isInstance);
   }
 

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/PerRequestToolFilteringHandlerTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/PerRequestToolFilteringHandlerTest.java
@@ -369,7 +369,7 @@ class PerRequestToolFilteringHandlerTest {
       .build();
     var tool = mock(Tool.class);
     when(tool.definition()).thenReturn(toolDef);
-    when(tool.getCategory()).thenReturn(category);
+    when(tool.getCategories()).thenReturn(Set.of(category));
     when(tool.isEnabledFor(any())).thenReturn(true);
     return tool;
   }


### PR DESCRIPTION
----
## Summary by Gitar

- **Tool categories:**
    - Updated `Tool` and `ToolCategory` classes to support multiple categories per tool using a `Set<ToolCategory>`
    - Updated filtering logic in `PerRequestToolFilteringHandler` and `SonarQubeMcpServer` to evaluate multiple categories

<sub>This will update automatically on new commits.</sub>