### PR TITLE
MCP-575 Add matching toolsets to invocation telemetry

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -282,8 +282,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
     // In stdio mode: pass the shared pre-resolved ConnectionContext
     // In HTTP mode: pass a supplier that captures the request-scoped ServerApi synchronously to the async analytics task
     this.toolExecutor = mcpConfiguration.isHttpEnabled()
-      ? new ToolExecutor(backendService, analyticsService, null, this, mcpConfiguration.getMcpServerId())
-      : new ToolExecutor(backendService, analyticsService, connectionContext, null, mcpConfiguration.getMcpServerId());
+      ? new ToolExecutor(backendService, analyticsService, null, this, mcpConfiguration.getMcpServerId(), this::resolveEnabledToolsets)
+      : new ToolExecutor(backendService, analyticsService, connectionContext, null, mcpConfiguration.getMcpServerId(), this::resolveEnabledToolsets);
 
     var configuredOrgKey = mcpConfiguration.getSonarqubeOrg();
     if (configuredOrgKey != null) {
@@ -579,6 +579,23 @@ public class SonarQubeMcpServer implements ServerApiProvider {
         return toolExecutor.execute(tool, toolRequest);
       })
       .build();
+  }
+
+  private Set<ToolCategory> resolveEnabledToolsets() {
+    var enabledToolsets = EnumSet.noneOf(ToolCategory.class);
+    ToolCategory.all().stream()
+      .filter(mcpConfiguration::isToolCategoryEnabled)
+      .forEach(enabledToolsets::add);
+
+    var transportContext = currentTransportContext.get();
+    if (transportContext != null) {
+      var requestToolsets = transportContext.get(HttpServerTransportProvider.CONTEXT_TOOLSETS_KEY);
+      if (requestToolsets instanceof Set<?> toolsets) {
+        enabledToolsets.removeIf(toolset -> !toolsets.contains(toolset));
+        enabledToolsets.add(ToolCategory.PROJECTS);
+      }
+    }
+    return enabledToolsets;
   }
 
   private void captureCallingAgent(McpSyncServerExchange exchange) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import jakarta.annotation.Nullable;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 import org.sonarsource.sonarqube.mcp.analytics.AnalyticsClient;
@@ -583,16 +584,15 @@ public class SonarQubeMcpServer implements ServerApiProvider {
 
   @VisibleForTesting
   Set<ToolCategory> resolveEnabledToolsets() {
-    var enabledToolsets = EnumSet.noneOf(ToolCategory.class);
-    ToolCategory.all().stream()
+    var enabledToolsets = ToolCategory.all().stream()
       .filter(mcpConfiguration::isToolCategoryEnabled)
-      .forEach(enabledToolsets::add);
+      .collect(Collectors.toCollection(() -> EnumSet.noneOf(ToolCategory.class)));
 
     var transportContext = currentTransportContext.get();
     if (transportContext != null) {
       var requestToolsets = transportContext.get(HttpServerTransportProvider.CONTEXT_TOOLSETS_KEY);
       if (requestToolsets instanceof Set<?> toolsets) {
-        enabledToolsets.removeIf(toolset -> !toolsets.contains(toolset));
+        enabledToolsets.retainAll(toolsets);
         enabledToolsets.add(ToolCategory.PROJECTS);
       }
     }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -581,7 +581,8 @@ public class SonarQubeMcpServer implements ServerApiProvider {
       .build();
   }
 
-  private Set<ToolCategory> resolveEnabledToolsets() {
+  @VisibleForTesting
+  Set<ToolCategory> resolveEnabledToolsets() {
     var enabledToolsets = EnumSet.noneOf(ToolCategory.class);
     ToolCategory.all().stream()
       .filter(mcpConfiguration::isToolCategoryEnabled)

--- a/src/main/java/org/sonarsource/sonarqube/mcp/analytics/AnalyticsService.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/analytics/AnalyticsService.java
@@ -93,7 +93,8 @@ public class AnalyticsService {
       result.errorType(),
       result.responseSizeBytes(),
       containerArch,
-      result.invocationTimestamp()
+      result.invocationTimestamp(),
+      result.matchingToolsets()
     );
 
     client.postEvent(event);

--- a/src/main/java/org/sonarsource/sonarqube/mcp/analytics/McpToolInvokedEvent.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/analytics/McpToolInvokedEvent.java
@@ -19,6 +19,7 @@ package org.sonarsource.sonarqube.mcp.analytics;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import jakarta.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -39,12 +40,13 @@ public record McpToolInvokedEvent(
   @JsonProperty("error_type") @Nullable String errorType,
   @JsonProperty("response_size_bytes") long responseSizeBytes,
   @JsonProperty("container_arch") @Nullable String containerArch,
-  @JsonProperty("invocation_timestamp") long invocationTimestamp
+  @JsonProperty("invocation_timestamp") long invocationTimestamp,
+  @JsonProperty("matching_toolsets") List<String> matchingToolsets
 ) implements AnalyticsEvent {
 
   private static final String EVENT_TYPE = "Analytics.Mcp.McpToolInvoked";
   // To update when the schema changes
-  private static final String EVENT_VERSION = "1";
+  private static final String EVENT_VERSION = "2";
 
   @Override
   @JsonIgnore

--- a/src/main/java/org/sonarsource/sonarqube/mcp/analytics/ToolInvocationResult.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/analytics/ToolInvocationResult.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.sonarqube.mcp.analytics;
 
+import java.util.List;
 import jakarta.annotation.Nullable;
 
 public record ToolInvocationResult(
@@ -30,6 +31,7 @@ public record ToolInvocationResult(
   boolean isSuccessful,
   @Nullable String errorType,
   long responseSizeBytes,
-  long invocationTimestamp
+  long invocationTimestamp,
+  List<String> matchingToolsets
 ) {
 }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/ToolExecutor.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/ToolExecutor.java
@@ -19,6 +19,8 @@ package org.sonarsource.sonarqube.mcp.tools;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 import jakarta.annotation.Nullable;
@@ -38,7 +40,8 @@ import org.sonarsource.sonarqube.mcp.tools.exception.MissingRequiredArgumentExce
 
 public class ToolExecutor {
   private static final McpLogger LOG = McpLogger.getInstance();
-  private record InvocationMetrics(String invocationId, long durationMs, boolean successful, @Nullable String errorType, long responseSizeBytes, long invocationTimestamp) {}
+  private record InvocationMetrics(String invocationId, long durationMs, boolean successful, @Nullable String errorType, long responseSizeBytes,
+    long invocationTimestamp, List<String> matchingToolsets) {}
   private final BackendService backendService;
   @Nullable
   private final AnalyticsService analyticsService;
@@ -61,17 +64,24 @@ public class ToolExecutor {
   @Nullable
   private final String mcpServerId;
 
+  /**
+   * Supplies the toolsets enabled for the current request.
+   */
+  private final Supplier<Set<ToolCategory>> enabledToolsetsSupplier;
+
   public ToolExecutor(BackendService backendService) {
-    this(backendService, null, null, null, null);
+    this(backendService, null, null, null, null, ToolCategory::all);
   }
 
   public ToolExecutor(BackendService backendService, @Nullable AnalyticsService analyticsService,
-    @Nullable ConnectionContext stdioContext, @Nullable Supplier<ServerApi> httpServerApiSupplier, @Nullable String mcpServerId) {
+    @Nullable ConnectionContext stdioContext, @Nullable Supplier<ServerApi> httpServerApiSupplier, @Nullable String mcpServerId,
+    Supplier<Set<ToolCategory>> enabledToolsetsSupplier) {
     this.backendService = backendService;
     this.analyticsService = analyticsService;
     this.stdioContext = stdioContext;
     this.httpServerApiSupplier = httpServerApiSupplier;
     this.mcpServerId = mcpServerId;
+    this.enabledToolsetsSupplier = enabledToolsetsSupplier;
   }
 
   public McpSchema.CallToolResult execute(Tool tool, McpSchema.CallToolRequest toolRequest) {
@@ -103,8 +113,14 @@ public class ToolExecutor {
     var successful = !result.isError();
     var callToolResult = result.toCallToolResult();
     var responseSizeBytes = computeResponseSizeBytes(callToolResult);
+    var enabledToolsets = enabledToolsetsSupplier.get();
+    var matchingToolsets = tool.getCategories().stream()
+      .filter(enabledToolsets::contains)
+      .map(ToolCategory::getKey)
+      .sorted()
+      .toList();
     backendService.notifyToolCalled("mcp_" + tool.definition().name(), successful);
-    notifyAnalytics(toolName, new InvocationMetrics(invocationId, durationMs, successful, errorType, responseSizeBytes, invocationTimestamp));
+    notifyAnalytics(toolName, new InvocationMetrics(invocationId, durationMs, successful, errorType, responseSizeBytes, invocationTimestamp, matchingToolsets));
     return callToolResult;
   }
 
@@ -147,7 +163,7 @@ public class ToolExecutor {
         ctx.getOrganizationUuidV4(), ctx.getSqsInstallationId(), ctx.getUserUuid(),
         ctx.getCallingAgentName(), ctx.getCallingAgentVersion(),
         metrics.durationMs(), metrics.successful(), metrics.errorType(),
-        metrics.responseSizeBytes(), metrics.invocationTimestamp()
+        metrics.responseSizeBytes(), metrics.invocationTimestamp(), metrics.matchingToolsets()
       ));
     } catch (Exception e) {
       LOG.debug("Failed to send analytics event for tool " + toolName + ": " + e.getMessage());

--- a/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerGenericTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerGenericTest.java
@@ -24,8 +24,10 @@ import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTest;
 import org.sonarsource.sonarqube.mcp.harness.SonarQubeMcpServerTestHarness;
+import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
 import org.sonarsource.sonarqube.mcp.tools.agenticreadiness.StartAgenticReadinessAssessmentTool;
 import org.sonarsource.sonarqube.mcp.tools.proxied.ProxiedMcpTool;
 import org.sonarsource.sonarqube.mcp.transport.HttpServerTransportProvider;
@@ -672,6 +674,29 @@ class SonarQubeMcpServerGenericTest {
     var context = McpTransportContext.create(Map.of(HttpServerTransportProvider.CONTEXT_TOKEN_KEY, "squ_valid_token"));
     server.withTransportContext(context, () ->
       assertThat(server.get()).isNotNull());
+
+    server.shutdown();
+  }
+
+  @SonarQubeMcpServerTest
+  void resolve_enabled_toolsets_should_apply_http_request_narrowing(SonarQubeMcpServerTestHarness harness) {
+    var environment = createHttpEnvironment(harness.getMockSonarQubeServer().baseUrl());
+    environment.put("SONARQUBE_TOOLSETS", "issues,rules");
+    harness.prepareMockWebServer(environment);
+
+    var server = new SonarQubeMcpServer(environment);
+    server.start();
+
+    var contextWithoutOverride = McpTransportContext.create(Map.of());
+    server.withTransportContext(contextWithoutOverride, () ->
+      assertThat(server.resolveEnabledToolsets()).containsExactlyInAnyOrder(
+        ToolCategory.ISSUES, ToolCategory.RULES, ToolCategory.PROJECTS));
+
+    var narrowedContext = McpTransportContext.create(Map.of(
+      HttpServerTransportProvider.CONTEXT_TOOLSETS_KEY, Set.of(ToolCategory.ISSUES)));
+    server.withTransportContext(narrowedContext, () ->
+      assertThat(server.resolveEnabledToolsets()).containsExactlyInAnyOrder(
+        ToolCategory.ISSUES, ToolCategory.PROJECTS));
 
     server.shutdown();
   }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/analytics/AnalyticsClientTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/analytics/AnalyticsClientTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarqube.mcp.http.HttpClientProvider;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -88,7 +89,8 @@ class AnalyticsClientTest {
       null,
       1024L,
       null,
-      System.currentTimeMillis()
+      System.currentTimeMillis(),
+      List.of("issues")
     );
 
     analyticsClient.postEvent(event);
@@ -117,7 +119,8 @@ class AnalyticsClientTest {
       "not_found",
       2048L,
       "amd64",
-      1000L
+      1000L,
+      List.of("issues")
     );
 
     analyticsClient.postEvent(event);
@@ -141,7 +144,7 @@ class AnalyticsClientTest {
           "source": {"domain": "MCP"},
           "event_type": "Analytics.Mcp.McpToolInvoked",
           "event_timestamp": "<event_timestamp>",
-          "event_version": "1"
+          "event_version": "2"
         },
         "event_payload": {
           "invocation_id": "inv-1",
@@ -158,7 +161,8 @@ class AnalyticsClientTest {
           "error_type": "not_found",
           "response_size_bytes": 2048,
           "container_arch": "amd64",
-          "invocation_timestamp": 1000
+          "invocation_timestamp": 1000,
+          "matching_toolsets": ["issues"]
         }
       }
       """;
@@ -169,7 +173,7 @@ class AnalyticsClientTest {
 
   @Test
   void it_should_send_x_api_key_header() {
-    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L);
+    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L, List.of());
 
     analyticsClient.postEvent(event);
 
@@ -183,7 +187,7 @@ class AnalyticsClientTest {
   void it_should_retry_up_to_twice_on_server_error() {
     wireMock.stubFor(post(urlPathEqualTo("/")).willReturn(aResponse().withStatus(500)));
 
-    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L);
+    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L, List.of());
     analyticsClient.postEvent(event);
 
     // 1 initial attempt + 2 retries = 3 total
@@ -196,7 +200,7 @@ class AnalyticsClientTest {
   void it_should_not_retry_on_client_error() {
     wireMock.stubFor(post(urlPathEqualTo("/")).willReturn(aResponse().withStatus(400)));
 
-    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L);
+    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L, List.of());
     analyticsClient.postEvent(event);
 
     await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
@@ -216,7 +220,7 @@ class AnalyticsClientTest {
       .whenScenarioStateIs("second-attempt")
       .willReturn(aResponse().withStatus(200)));
 
-    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L);
+    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L, List.of());
     analyticsClient.postEvent(event);
 
     await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
@@ -230,7 +234,7 @@ class AnalyticsClientTest {
     System.setProperty(AnalyticsClient.PROPERTY_ANALYTICS_ENDPOINT, "http://192.0.2.1:9999/mcp");
     var unreachableClient = new AnalyticsClient(httpClient);
 
-    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L);
+    var event = new McpToolInvokedEvent("id", "tool", "SQS", null, null, null, "srv", "1.0.0", "stdio", null, null, 100L, true, null, 0L, null, 0L, List.of());
 
     assertThatCode(() -> unreachableClient.postEvent(event)).doesNotThrowAnyException();
   }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/analytics/AnalyticsServiceTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/analytics/AnalyticsServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.sonarqube.mcp.analytics;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +40,8 @@ class AnalyticsServiceTest {
   void it_should_build_sqc_event_with_org_uuid() {
     var service = new AnalyticsService(mockClient, "server-id", "1.11.0.14345", false, false, true);
 
-    service.notifyToolInvoked(new ToolInvocationResult("inv-123", "search_issues", "org-uuid-123", null, "user-uuid-456", "cursor", "1.0.0", 123L, true, null, 512L, 1000L));
+    service.notifyToolInvoked(new ToolInvocationResult("inv-123", "search_issues", "org-uuid-123", null, "user-uuid-456", "cursor", "1.0.0", 123L, true, null, 512L, 1000L,
+      List.of("issues")));
 
     var captor = ArgumentCaptor.forClass(McpToolInvokedEvent.class);
     verify(mockClient).postEvent(captor.capture());
@@ -61,13 +63,15 @@ class AnalyticsServiceTest {
     assertThat(event.errorType()).isNull();
     assertThat(event.responseSizeBytes()).isEqualTo(512L);
     assertThat(event.invocationTimestamp()).isEqualTo(1000L);
+    assertThat(event.matchingToolsets()).containsExactly("issues");
   }
 
   @Test
   void it_should_build_sqs_event_with_installation_id() {
     var service = new AnalyticsService(mockClient, "server-id", "1.11.0.14345", true, false, false);
 
-    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "show_rule", null, "install-abc", null, null, null, 42L, false, "not_found", 0L, 2000L));
+    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "show_rule", null, "install-abc", null, null, null, 42L, false, "not_found", 0L, 2000L,
+      List.of("rules")));
 
     var captor = ArgumentCaptor.forClass(McpToolInvokedEvent.class);
     verify(mockClient).postEvent(captor.capture());
@@ -91,7 +95,8 @@ class AnalyticsServiceTest {
   void it_should_ignore_sqs_installation_id_for_sqc_connection() {
     var service = new AnalyticsService(mockClient, "server-id", "1.0.0", false, false, true);
 
-    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "search_issues", "org-uuid", "should-be-ignored", "user-uuid", null, null, 0L, true, null, 0L, 0L));
+    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "search_issues", "org-uuid", "should-be-ignored", "user-uuid", null, null, 0L, true, null, 0L, 0L,
+      List.of("issues")));
 
     var captor = ArgumentCaptor.forClass(McpToolInvokedEvent.class);
     verify(mockClient).postEvent(captor.capture());
@@ -106,7 +111,8 @@ class AnalyticsServiceTest {
   void it_should_ignore_org_uuid_for_sqs_connection() {
     var service = new AnalyticsService(mockClient, "server-id", "1.0.0", false, false, false);
 
-    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "search_issues", "should-be-ignored", "install-id", null, null, null, 0L, true, null, 0L, 0L));
+    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "search_issues", "should-be-ignored", "install-id", null, null, null, 0L, true, null, 0L, 0L,
+      List.of("issues")));
 
     var captor = ArgumentCaptor.forClass(McpToolInvokedEvent.class);
     verify(mockClient).postEvent(captor.capture());
@@ -121,7 +127,7 @@ class AnalyticsServiceTest {
   void it_should_resolve_transport_mode_as_stdio_when_http_disabled() {
     var service = new AnalyticsService(mockClient, "server-id", "1.0.0", false, false, false);
 
-    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "tool", null, null, null, null, null, 0L, true, null, 0L, 0L));
+    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "tool", null, null, null, null, null, 0L, true, null, 0L, 0L, List.of()));
 
     var captor = ArgumentCaptor.forClass(McpToolInvokedEvent.class);
     verify(mockClient).postEvent(captor.capture());
@@ -132,7 +138,7 @@ class AnalyticsServiceTest {
   void it_should_resolve_transport_mode_as_http_when_http_enabled_without_tls() {
     var service = new AnalyticsService(mockClient, "server-id", "1.0.0", true, false, false);
 
-    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "tool", null, null, null, null, null, 0L, true, null, 0L, 0L));
+    service.notifyToolInvoked(new ToolInvocationResult("inv-id", "tool", null, null, null, null, null, 0L, true, null, 0L, 0L, List.of()));
 
     var captor = ArgumentCaptor.forClass(McpToolInvokedEvent.class);
     verify(mockClient).postEvent(captor.capture());

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolExecutorTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/ToolExecutorTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
@@ -175,7 +176,7 @@ class ToolExecutorTest {
     var analyticsService = mock(AnalyticsService.class);
     doAnswer(invocation -> { ((Runnable) invocation.getArgument(0)).run(); return null; })
       .when(analyticsService).submit(any(Runnable.class));
-    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, null);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, null, ToolCategory::all);
     var resultCaptor = ArgumentCaptor.forClass(ToolInvocationResult.class);
 
     executor.execute(new Tool(McpSchema.Tool.builder("tool_name", EMPTY_INPUT_SCHEMA).title("test description").description("").build(), ToolCategory.ANALYSIS) {
@@ -191,7 +192,7 @@ class ToolExecutorTest {
 
   @Test
   void it_should_skip_analytics_when_service_is_null() {
-    var executor = new ToolExecutor(mockBackendService, null, ConnectionContext.empty(), null, null);
+    var executor = new ToolExecutor(mockBackendService, null, ConnectionContext.empty(), null, null, ToolCategory::all);
 
     var result = executeDummyTool(executor);
 
@@ -203,7 +204,7 @@ class ToolExecutorTest {
     var analyticsService = syncAnalyticsService();
     var ctx = ConnectionContext.empty();
     ctx.captureCallingAgent("cursor", "1.0.0");
-    var executor = new ToolExecutor(mockBackendService, analyticsService, ctx, null, null);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, ctx, null, null, ToolCategory::all);
 
     executeDummyTool(executor);
 
@@ -211,9 +212,30 @@ class ToolExecutorTest {
   }
 
   @Test
+  void it_should_report_the_intersection_of_enabled_toolsets_and_tool_categories() {
+    var analyticsService = syncAnalyticsService();
+    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, null,
+      () -> Set.of(ToolCategory.VORTEX, ToolCategory.ISSUES, ToolCategory.ANALYSIS));
+    record TestResponse(@JsonPropertyDescription("Result") String value) {}
+    var tool = new Tool(McpSchema.Tool.builder("tool_name", EMPTY_INPUT_SCHEMA).title("test description").description("").build(),
+      ToolCategory.ANALYSIS, ToolCategory.VORTEX) {
+      @Override
+      public Result execute(Arguments arguments) {
+        return Result.success(new TestResponse("ok"));
+      }
+    };
+
+    executor.execute(tool, McpSchema.CallToolRequest.builder("tool_name").arguments(Map.of()).build());
+
+    var resultCaptor = ArgumentCaptor.forClass(ToolInvocationResult.class);
+    verify(analyticsService).notifyToolInvoked(resultCaptor.capture());
+    assertThat(resultCaptor.getValue().matchingToolsets()).containsExactly("analysis", "vortex");
+  }
+
+  @Test
   void it_should_skip_analytics_when_both_context_and_supplier_are_null() {
     var analyticsService = syncAnalyticsService();
-    var executor = new ToolExecutor(mockBackendService, analyticsService, null, null, null);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, null, null, null, ToolCategory::all);
 
     executeDummyTool(executor);
 
@@ -224,7 +246,7 @@ class ToolExecutorTest {
   void it_should_dispatch_event_in_http_mode_and_resolve_context_from_server_api() {
     var analyticsService = syncAnalyticsService();
     var mockServerApi = mock(ServerApi.class, RETURNS_DEEP_STUBS);
-    var executor = new ToolExecutor(mockBackendService, analyticsService, null, () -> mockServerApi, null);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, null, () -> mockServerApi, null, ToolCategory::all);
 
     executeDummyTool(executor);
 
@@ -236,7 +258,7 @@ class ToolExecutorTest {
   void it_should_skip_analytics_in_http_mode_when_supplier_throws() {
     var analyticsService = syncAnalyticsService();
     var executor = new ToolExecutor(mockBackendService, analyticsService, null,
-      () -> { throw new RuntimeException("no transport context"); }, null);
+      () -> { throw new RuntimeException("no transport context"); }, null, ToolCategory::all);
 
     executeDummyTool(executor);
 
@@ -248,7 +270,7 @@ class ToolExecutorTest {
     var analyticsService = syncAnalyticsService();
     var mockServerApi = mock(ServerApi.class, RETURNS_DEEP_STUBS);
     doThrow(new RuntimeException("API unavailable")).when(mockServerApi).isSonarQubeCloud();
-    var executor = new ToolExecutor(mockBackendService, analyticsService, null, () -> mockServerApi, null);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, null, () -> mockServerApi, null, ToolCategory::all);
 
     executeDummyTool(executor);
 
@@ -258,11 +280,12 @@ class ToolExecutorTest {
   @Test
   void it_should_inject_invocation_id_into_tool_arguments_and_analytics() {
     var analyticsService = syncAnalyticsService();
-    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, null);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, null, ToolCategory::all);
     var tool = mock(Tool.class);
     var toolDefinition = McpSchema.Tool.builder("test_tool", EMPTY_INPUT_SCHEMA).title("desc").description("").build();
     record DummyResponse(String message) {}
     when(tool.definition()).thenReturn(toolDefinition);
+    when(tool.getCategories()).thenReturn(Set.of(ToolCategory.ANALYSIS));
     when(tool.execute(any())).thenReturn(Tool.Result.success(new DummyResponse("ok")));
 
     var toolRequest = McpSchema.CallToolRequest.builder("test_tool")
@@ -292,11 +315,12 @@ class ToolExecutorTest {
   void it_should_inject_mcp_server_id_into_tool_arguments() {
     var analyticsService = syncAnalyticsService();
     var mcpServerId = "test-server-id-12345";
-    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, mcpServerId);
+    var executor = new ToolExecutor(mockBackendService, analyticsService, ConnectionContext.empty(), null, mcpServerId, ToolCategory::all);
     var tool = mock(Tool.class);
     var toolDefinition = McpSchema.Tool.builder("test_tool", EMPTY_INPUT_SCHEMA).title("desc").description("").build();
     record DummyResponse(String message) {}
     when(tool.definition()).thenReturn(toolDefinition);
+    when(tool.getCategories()).thenReturn(Set.of(ToolCategory.ANALYSIS));
     when(tool.execute(any())).thenReturn(Tool.Result.success(new DummyResponse("ok")));
 
     var toolRequest = McpSchema.CallToolRequest.builder("test_tool")


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry enhancement:**
    - Added matching toolsets to `McpToolInvokedEvent` analytics telemetry and bumped event version to `2`
    - Updated `ToolExecutor` and `SonarQubeMcpServer` to resolve and pass enabled toolsets for tool invocations

<sub>This will update automatically on new commits.</sub>