### PR TITLE
MCP-572 Deprecate `analyze_code_snippet` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ By default, only important toolsets are enabled to reduce context overhead. You 
 
 | Toolset               | Key                 | Description                                                                                                                                                 |
 |-----------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Analysis**          | `analysis`          | Code analysis tools (local analysis; Vortex analysis, deprecated in favor of `vortex`)                                                                      |
+| **Analysis**          | `analysis`          | Code analysis tools (local analysis via `analyze_code_snippet`, **deprecated** in favor of `analyze_file_list`/Vortex analysis)                                                                      |
 | **IDE**               | `ide`               | SonarQube for IDE bridge tools (file analysis, automatic analysis toggle) — currently also included in `analysis`                                           |
 | **Issues**            | `issues`            | Search and manage SonarQube issues                                                                                                                          |
 | **Security Hotspots** | `security-hotspots` | Search and review Security Hotspots                                                                                                                         |
@@ -994,6 +994,8 @@ Omit `-Djavax.net.ssl.keyStorePassword` if the keystore has no passphrase.
 ### Analysis
 
 - **analyze_code_snippet** - Analyze file content with SonarQube analyzers to identify code quality and security issues. Always analyzes the complete file content for accuracy. Optionally filter results to a specific code snippet.
+
+  > **Deprecated:** `analyze_code_snippet` will be removed in a future release. Connect SonarQube for IDE to use `analyze_file_list`, or enable Vortex analysis for your organization to use `run_advanced_code_analysis` (see below).
   
   Usage:
   - **With workspace mounted** (recommended): pass `filePath` (project-relative) — the server reads the file directly, keeping file content out of the agent context window

--- a/docs/tool-loading.md
+++ b/docs/tool-loading.md
@@ -80,7 +80,7 @@ All tools are registered at startup:
 - No analyzer dependency
 
 **Analysis Tools** - Available immediately, fully functional after Phase 2
-- `analyze_code_snippet` - Analyzes code using SonarLint backend
+- `analyze_code_snippet` - Analyzes code using SonarLint backend. **Deprecated** in favor of `analyze_file_list` and Vortex toolset, will be removed in a future release
 - `analyze_file_list` - Uses IDE bridge (if available); also tagged under the `ide` toolset alongside `analysis`
 - Analysis works once analyzers are downloaded
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetTool.java
@@ -57,6 +57,8 @@ public class AnalyzeCodeSnippetTool extends Tool {
   }
 
   public static final String TOOL_NAME = "analyze_code_snippet";
+  public static final String DEPRECATION_NOTICE = "analyze_code_snippet is deprecated and will be removed in a future release. " +
+    "Connect SonarQube for IDE for analyze_file_list, or enable Vortex analysis for run_advanced_code_analysis, for more accurate, cross-file results.";
   public static final String PROJECT_KEY_PROPERTY = ToolParameters.PROJECT_KEY;
   public static final String FILE_PATH_PROPERTY = "filePath";
   public static final String FILE_CONTENT_PROPERTY = "fileContent";
@@ -93,7 +95,9 @@ public class AnalyzeCodeSnippetTool extends Tool {
       .setTitle("SonarQube Code Analysis")
       .setDescription("Analyze a file or code snippet to identify code quality and security issues. " +
         "Optionally provide a code snippet to filter issues — only issues within the snippet will be reported (snippet location is auto-detected). " +
-        "Always specify the language and the file scope (MAIN or TEST) for more accurate results.")
+        "Always specify the language and the file scope (MAIN or TEST) for more accurate results. " +
+        "This tool is deprecated and will be removed in a future release. For richer, cross-file analysis, " +
+        "connect SonarQube for IDE (enables analyze_file_list) or enable Vortex analysis (run_advanced_code_analysis).")
       .addOptionalProjectKeyProperty(PROJECT_KEY_PROPERTY, configuredProjectKey);
     if (workspaceConfigured) {
       builder = builder.addRequiredStringProperty(FILE_PATH_PROPERTY, "Project-relative path of the file to analyze (e.g., 'src/main/java/MyClass.java').");
@@ -297,7 +301,7 @@ public class AnalyzeCodeSnippetTool extends Tool {
       filteredIssues = allIssues;
     }
 
-    return new AnalyzeCodeSnippetToolResponse(filteredIssues, filteredIssues.size());
+    return new AnalyzeCodeSnippetToolResponse(filteredIssues, filteredIssues.size(), DEPRECATION_NOTICE);
   }
 
   private static Tool.Result handleInitializationError(Exception e, long startTime) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolResponse.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record AnalyzeCodeSnippetToolResponse(
   @JsonPropertyDescription("List of issues found in the code snippet") List<Issue> issues,
-  @JsonPropertyDescription("Total number of issues") int issueCount
+  @JsonPropertyDescription("Total number of issues") int issueCount,
+  @JsonPropertyDescription("Deprecation notice for this tool") String deprecationNotice
 ) {
   
   public record Issue(

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/analysis/AnalyzeCodeSnippetToolTests.java
@@ -61,6 +61,10 @@ class AnalyzeCodeSnippetToolTests {
       {
         "type": "object",
         "properties": {
+          "deprecationNotice": {
+            "type": "string",
+            "description": "Deprecation notice for this tool"
+          },
           "issueCount": {
             "type": "integer",
             "description": "Total number of issues"
@@ -122,7 +126,7 @@ class AnalyzeCodeSnippetToolTests {
             }
           }
         },
-        "required": ["issueCount", "issues"]
+        "required": ["deprecationNotice", "issueCount", "issues"]
       }
       """);
   }
@@ -196,8 +200,9 @@ class AnalyzeCodeSnippetToolTests {
               "endLine" : 1
             }
           } ],
-          "issueCount" : 1
-        }""");
+          "issueCount" : 1,
+          "deprecationNotice" : "%s"
+        }""".formatted(AnalyzeCodeSnippetTool.DEPRECATION_NOTICE));
     }
 
     @SonarQubeMcpServerTest
@@ -230,8 +235,9 @@ class AnalyzeCodeSnippetToolTests {
                  }
               }
            ],
-           "issueCount":1
-        }""");
+           "issueCount":1,
+           "deprecationNotice":"%s"
+        }""".formatted(AnalyzeCodeSnippetTool.DEPRECATION_NOTICE));
     }
 
     @SonarQubeMcpServerTest
@@ -247,7 +253,7 @@ class AnalyzeCodeSnippetToolTests {
             """,
           AnalyzeCodeSnippetTool.LANGUAGE_PROPERTY, "php"));
 
-      assertResultEquals(result, "{\"issues\":[],\"issueCount\":0}");
+      assertResultEquals(result, "{\"issues\":[],\"issueCount\":0,\"deprecationNotice\":\"%s\"}".formatted(AnalyzeCodeSnippetTool.DEPRECATION_NOTICE));
     }
 
     @SonarQubeMcpServerTest
@@ -278,8 +284,9 @@ class AnalyzeCodeSnippetToolTests {
               "endLine" : 1
             }
           } ],
-          "issueCount" : 1
-        }""");
+          "issueCount" : 1,
+          "deprecationNotice" : "%s"
+        }""".formatted(AnalyzeCodeSnippetTool.DEPRECATION_NOTICE));
     }
 
     @SonarQubeMcpServerTest
@@ -296,7 +303,7 @@ class AnalyzeCodeSnippetToolTests {
           AnalyzeCodeSnippetTool.LANGUAGE_PROPERTY, "php",
           AnalyzeCodeSnippetTool.SCOPE_PROPERTY, "TEST"));
 
-      assertResultEquals(result, "{\"issues\":[],\"issueCount\":0}");
+      assertResultEquals(result, "{\"issues\":[],\"issueCount\":0,\"deprecationNotice\":\"%s\"}".formatted(AnalyzeCodeSnippetTool.DEPRECATION_NOTICE));
     }
 
     @SonarQubeMcpServerTest
@@ -324,8 +331,9 @@ class AnalyzeCodeSnippetToolTests {
               "endLine" : 1
             }
           } ],
-          "issueCount" : 1
-        }""");
+          "issueCount" : 1,
+          "deprecationNotice" : "%s"
+        }""".formatted(AnalyzeCodeSnippetTool.DEPRECATION_NOTICE));
     }
 
     @SonarQubeMcpServerTest


### PR DESCRIPTION
The tool is already loaded only if both vortex and ide tools are not possible, just adding notes about deprecation into response and documentation.