### PR TITLE
MCP-600 HTTPS liveness probe returns 400 Invalid SNI

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportProvider.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/HttpServerTransportProvider.java
@@ -35,6 +35,9 @@ import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -227,12 +230,11 @@ public class HttpServerTransportProvider {
     ServerConnector connector;
 
     if (httpsEnabled) {
-      // Configure HTTPS with SSL/TLS
       var sslContextFactory = new SslContextFactory.Server();
       var sslContext = configureSsl(httpsKeystorePath, httpsKeystorePassword, httpsKeystoreType,
         httpsTruststorePath, httpsTruststorePassword, httpsTruststoreType);
       sslContextFactory.setSslContext(sslContext);
-      connector = new ServerConnector(httpServer, sslContextFactory);
+      connector = createHttpsConnector(httpServer, sslContextFactory);
     } else {
       // Plain HTTP connector
       connector = new ServerConnector(httpServer);
@@ -289,6 +291,19 @@ public class HttpServerTransportProvider {
   public String getServerUrl() {
     var protocol = httpsEnabled ? "https" : "http";
     return protocol + "://" + host + ":" + port + MCP_ENDPOINT;
+  }
+
+  /**
+   * Jetty 12 rejects requests whose Host/SNI is not in the certificate (HTTP 400 Invalid SNI).
+   * Kubernetes HTTPS probes connect via the pod IP, which will not match typical service DNS SANs.
+   */
+  private static ServerConnector createHttpsConnector(Server server, SslContextFactory.Server sslContextFactory) {
+    var httpsConfig = new HttpConfiguration();
+    var secureCustomizer = new SecureRequestCustomizer();
+    secureCustomizer.setSniRequired(false);
+    secureCustomizer.setSniHostCheck(false);
+    httpsConfig.addCustomizer(secureCustomizer);
+    return new ServerConnector(server, sslContextFactory, new HttpConnectionFactory(httpsConfig));
   }
 
   /**

--- a/src/test/java/org/sonarsource/sonarqube/mcp/harness/SslTestUtils.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/harness/SslTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.harness;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public final class SslTestUtils {
+
+  private SslTestUtils() {
+    // utility class
+  }
+
+  public static SSLContext trustAllSslContext() {
+    try {
+      var sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, new TrustManager[] {new TrustAllManager()}, new SecureRandom());
+      return sslContext;
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("Failed to create trust-all SSL context", e);
+    }
+  }
+
+  public static int getResponseCodeTrustingAllCertificates(String url, Duration connectTimeout, Duration readTimeout)
+    throws IOException {
+    var connection = (HttpsURLConnection) URI.create(url).toURL().openConnection();
+    connection.setSSLSocketFactory(trustAllSslContext().getSocketFactory());
+    connection.setHostnameVerifier((hostname, session) -> true);
+    connection.setConnectTimeout(Math.toIntExact(connectTimeout.toMillis()));
+    connection.setReadTimeout(Math.toIntExact(readTimeout.toMillis()));
+    connection.setRequestMethod("GET");
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private static final class TrustAllManager implements X509TrustManager {
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      // Test client accepts any server certificate
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      // Test client accepts any server certificate
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      return new X509Certificate[0];
+    }
+  }
+
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpsServerTransportIntegrationTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/HttpsServerTransportIntegrationTest.java
@@ -22,12 +22,14 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarqube.mcp.authentication.AuthMode;
+import org.sonarsource.sonarqube.mcp.harness.SslTestUtils;
 
 class HttpsServerTransportIntegrationTest {
 
@@ -109,6 +111,19 @@ class HttpsServerTransportIntegrationTest {
     var startFuture2 = httpsServer.startServer();
     startFuture2.get(5, TimeUnit.SECONDS);
     assertThat(startFuture2).isCompleted();
+  }
+
+  @Test
+  void should_return_health_ok_when_request_host_is_not_in_certificate() throws Exception {
+    httpsServer.startServer().get(5, TimeUnit.SECONDS);
+
+    // kubelet HTTPS probes connect to the pod IP; the Host header is therefore an address that
+    // is not present in the certificate (test cert CN=localhost).
+    var healthUrl = "https://127.0.0.1:" + testPort + McpSecurityFilter.HEALTH_ENDPOINT;
+    var statusCode = SslTestUtils.getResponseCodeTrustingAllCertificates(
+      healthUrl, Duration.ofSeconds(5), Duration.ofSeconds(5));
+
+    assertThat(statusCode).isEqualTo(200);
   }
 
   @Test


### PR DESCRIPTION
----
## Summary by Gitar

- **Transport:**
    - Disabled SNI and hostname checks in `HttpServerTransportProvider` to allow Kubernetes IP-based HTTPS probes

<sub>This will update automatically on new commits.</sub>