### PR TITLE
MCP-608 Answer MCP initialize with an error on stdio startup failure

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServer.java
@@ -26,6 +26,8 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -99,6 +101,7 @@ import org.sonarsource.sonarqube.mcp.tools.agenticreadiness.StartAgenticReadines
 import org.sonarsource.sonarqube.mcp.tools.webhooks.CreateWebhookTool;
 import org.sonarsource.sonarqube.mcp.tools.webhooks.ListWebhooksTool;
 import org.sonarsource.sonarqube.mcp.transport.HttpServerTransportProvider;
+import org.sonarsource.sonarqube.mcp.transport.StdioInitializeErrorReporter;
 import org.sonarsource.sonarqube.mcp.transport.StdioServerTransportProvider;
 
 public class SonarQubeMcpServer implements ServerApiProvider {
@@ -201,7 +204,20 @@ public class SonarQubeMcpServer implements ServerApiProvider {
   private ProxiedToolsLoader proxiedToolsLoader;
 
   public static void main(String[] args) {
-    new SonarQubeMcpServer(System.getenv()).start();
+    try {
+      new SonarQubeMcpServer(System.getenv()).start();
+    } catch (RuntimeException e) {
+      handleStartupFailure(e, System.getenv(), System.in, System.out);
+      System.exit(1);
+    }
+  }
+
+  @VisibleForTesting
+  static void handleStartupFailure(RuntimeException error, Map<String, String> environment, InputStream in, OutputStream out) {
+    LOG.error("Failed to start SonarQube MCP Server", error);
+    if (!McpServerLaunchConfiguration.isHttpTransport(environment)) {
+      StdioInitializeErrorReporter.report(error, in, out);
+    }
   }
 
   public SonarQubeMcpServer(Map<String, String> environment) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -150,9 +150,8 @@ public class McpServerLaunchConfiguration {
     this.storagePath = Paths.get(storagePathString);
     this.hostMachineAddress = resolveHostMachineAddress();
 
-    var transportMode = requireNonNull(getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_TRANSPORT, "")).toLowerCase(Locale.getDefault());
-    this.isHttpEnabled = transportMode.equals("http") || transportMode.equals("https");
-    this.isHttpsEnabled = transportMode.equals("https");
+    this.isHttpEnabled = isHttpTransport(environment);
+    this.isHttpsEnabled = "https".equals(transportMode(environment));
 
     // Read configuration values.
     // SONARQUBE_TOKEN, SONARQUBE_ORG, and SONARQUBE_URL may be forwarded as literal "${VAR}" strings by MCP clients
@@ -286,6 +285,19 @@ public class McpServerLaunchConfiguration {
 
   public boolean isHttpEnabled() {
     return isHttpEnabled;
+  }
+
+  /**
+   * True when {@code SONARQUBE_TRANSPORT} is {@code http} or {@code https}.
+   * Safe to call even when constructing {@link McpServerLaunchConfiguration} would fail.
+   */
+  public static boolean isHttpTransport(Map<String, String> environment) {
+    var mode = transportMode(environment);
+    return "http".equals(mode) || "https".equals(mode);
+  }
+
+  private static String transportMode(Map<String, String> environment) {
+    return requireNonNull(getValueViaEnvOrPropertyOrDefault(environment, SONARQUBE_TRANSPORT, "")).toLowerCase(Locale.getDefault());
   }
 
   public int getHttpPort() {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/transport/StdioInitializeErrorReporter.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/transport/StdioInitializeErrorReporter.java
@@ -1,0 +1,106 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.transport;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.sonarsource.sonarqube.mcp.log.McpLogger;
+
+/**
+ * Stdio launch failures (missing token, URL, storage path, …) otherwise kill the process
+ * before MCP {@code initialize}. Waiting for that request and returning a JSON-RPC error
+ * lets clients show the real cause instead of Connection closed.
+ */
+public final class StdioInitializeErrorReporter {
+
+  private static final McpLogger LOG = McpLogger.getInstance();
+  private static final Duration DEFAULT_WAIT = Duration.ofSeconds(10);
+
+  private StdioInitializeErrorReporter() {
+  }
+
+  public static void report(Throwable error, InputStream in, OutputStream out) {
+    var errorMessage = (error.getMessage() == null || error.getMessage().isBlank()) ? error.toString() : error.getMessage();
+    if (isInteractiveStdin(in)) {
+      return;
+    }
+    respondToInitialize(errorMessage, in, out, DEFAULT_WAIT);
+  }
+
+  @VisibleForTesting
+  static void respondToInitialize(String errorMessage, InputStream in, OutputStream out, Duration timeout) {
+    var thread = Thread.ofPlatform()
+      .name("stdio-initialize-error")
+      .daemon()
+      .start(() -> {
+        try {
+          writeErrorForInitialize(errorMessage, in, out);
+        } catch (IOException e) {
+          LOG.error("Failed to send MCP initialize error to client", e);
+        }
+      });
+    try {
+      thread.join(timeout.toMillis());
+      if (thread.isAlive()) {
+        thread.interrupt();
+        LOG.error("Timed out waiting for MCP initialize request after startup failure");
+      }
+    } catch (InterruptedException e) {
+      thread.interrupt();
+      Thread.currentThread().interrupt();
+      LOG.error("Interrupted while reporting MCP initialize error");
+    }
+  }
+
+  private static boolean isInteractiveStdin(InputStream in) {
+    return in == System.in && System.console() != null;
+  }
+
+  private static void writeErrorForInitialize(String errorMessage, InputStream in, OutputStream out) throws IOException {
+    var reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+    String line;
+    while ((line = reader.readLine()) != null) {
+      var request = line.isBlank() ? null : parseInitializeRequest(line);
+      if (request != null) {
+        var error = new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR, errorMessage);
+        var response = McpSchema.JSONRPCResponse.error(request.id(), error);
+        out.write((McpJsonMappers.DEFAULT.writeValueAsString(response) + "\n").getBytes(StandardCharsets.UTF_8));
+        out.flush();
+        return;
+      }
+    }
+  }
+
+  private static McpSchema.JSONRPCRequest parseInitializeRequest(String line) {
+    try {
+      var parsed = McpSchema.deserializeJsonRpcMessage(McpJsonMappers.DEFAULT, line);
+      if (parsed instanceof McpSchema.JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+        return request;
+      }
+    } catch (IOException | IllegalArgumentException e) {
+      LOG.debug("Ignoring non-JSON-RPC line while reporting startup failure: {}", e.getMessage());
+    }
+    return null;
+  }
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerStartupFailureTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/SonarQubeMcpServerStartupFailureTest.java
@@ -1,0 +1,77 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.sonarsource.sonarqube.mcp.transport.McpJsonMappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SonarQubeMcpServerStartupFailureTest {
+
+  private static final String INITIALIZE = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n";
+
+  @Test
+  void should_not_write_to_stdout_when_http_transport_is_enabled() {
+    var out = new ByteArrayOutputStream();
+
+    SonarQubeMcpServer.handleStartupFailure(
+      new IllegalArgumentException("invalid keystore"),
+      Map.of("SONARQUBE_TRANSPORT", "http"),
+      new ByteArrayInputStream(INITIALIZE.getBytes(StandardCharsets.UTF_8)),
+      out);
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEmpty();
+  }
+
+  @Test
+  void should_not_write_to_stdout_when_https_transport_is_enabled() {
+    var out = new ByteArrayOutputStream();
+
+    SonarQubeMcpServer.handleStartupFailure(
+      new IllegalArgumentException("invalid keystore"),
+      Map.of("SONARQUBE_TRANSPORT", "https"),
+      new ByteArrayInputStream(INITIALIZE.getBytes(StandardCharsets.UTF_8)),
+      out);
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEmpty();
+  }
+
+  @Test
+  void should_reply_to_initialize_when_stdio_startup_fails() throws IOException {
+    var out = new ByteArrayOutputStream();
+
+    SonarQubeMcpServer.handleStartupFailure(
+      new IllegalArgumentException("SONARQUBE_TOKEN environment variable or property must be set"),
+      Map.of(),
+      new ByteArrayInputStream(INITIALIZE.getBytes(StandardCharsets.UTF_8)),
+      out);
+
+    var parsed = McpSchema.deserializeJsonRpcMessage(McpJsonMappers.DEFAULT, out.toString(StandardCharsets.UTF_8).trim());
+    assertThat(parsed).isInstanceOf(McpSchema.JSONRPCResponse.class);
+    var response = (McpSchema.JSONRPCResponse) parsed;
+    assertThat(response.id()).isEqualTo(1);
+    assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+    assertThat(response.error().message()).contains("SONARQUBE_TOKEN");
+  }
+}

--- a/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationHttpTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfigurationHttpTest.java
@@ -61,6 +61,14 @@ class McpServerLaunchConfigurationHttpTest {
   }
 
   @Test
+  void should_detect_http_transport_without_full_configuration() {
+    assertThat(McpServerLaunchConfiguration.isHttpTransport(Map.of("SONARQUBE_TRANSPORT", "http"))).isTrue();
+    assertThat(McpServerLaunchConfiguration.isHttpTransport(Map.of("SONARQUBE_TRANSPORT", "HTTPS"))).isTrue();
+    assertThat(McpServerLaunchConfiguration.isHttpTransport(Map.of())).isFalse();
+    assertThat(McpServerLaunchConfiguration.isHttpTransport(Map.of("SONARQUBE_TRANSPORT", "stdio"))).isFalse();
+  }
+
+  @Test
   void should_parse_http_enabled_false() {
     var environment = createMinimalTestEnvironment();
     environment.put("SONARQUBE_TRANSPORT", "false");

--- a/src/test/java/org/sonarsource/sonarqube/mcp/transport/StdioInitializeErrorReporterTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/transport/StdioInitializeErrorReporterTest.java
@@ -1,0 +1,195 @@
+/*
+ * SonarQube MCP Server
+ * Copyright (C) SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.sonarqube.mcp.transport;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class StdioInitializeErrorReporterTest {
+
+  @Test
+  void should_reply_to_initialize_with_jsonrpc_error() {
+    var response = respondTo("""
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+      """, "SONARQUBE_TOKEN environment variable or property must be set");
+
+    assertThat(response.id()).isEqualTo(1);
+    assertThat(response.error().code()).isEqualTo(McpSchema.ErrorCodes.INTERNAL_ERROR);
+    assertThat(response.error().message()).contains("SONARQUBE_TOKEN");
+  }
+
+  @Test
+  void should_skip_non_initialize_lines_then_respond() {
+    var response = respondTo("""
+      not-json
+      {"jsonrpc":"2.0","id":"abc","method":"initialize"}
+      """, "auth failed");
+
+    assertThat(response.id()).isEqualTo("abc");
+    assertThat(response.error().message()).isEqualTo("auth failed");
+  }
+
+  @Test
+  void should_preserve_quotes_and_newlines_in_error_message() {
+    var response = respondTo("""
+      {"jsonrpc":"2.0","id":3,"method":"initialize"}
+      """, "Say \"hello\"\nthen reconnect");
+
+    assertThat(response.error().message()).isEqualTo("Say \"hello\"\nthen reconnect");
+  }
+
+  @Test
+  void should_return_without_output_when_stdin_has_no_initialize() {
+    var out = new ByteArrayOutputStream();
+
+    StdioInitializeErrorReporter.respondToInitialize(
+      "auth failed",
+      stream("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n"),
+      out,
+      Duration.ofSeconds(2));
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEmpty();
+  }
+
+  @Test
+  void should_return_without_output_when_stdin_is_already_ended() {
+    var out = new ByteArrayOutputStream();
+
+    StdioInitializeErrorReporter.respondToInitialize(
+      "auth failed",
+      new ByteArrayInputStream(new byte[0]),
+      out,
+      Duration.ofSeconds(2));
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEmpty();
+  }
+
+  @Test
+  void should_use_exception_to_string_when_message_is_blank() {
+    var out = new ByteArrayOutputStream();
+
+    StdioInitializeErrorReporter.report(
+      new IllegalStateException(""),
+      stream("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"initialize\"}\n"),
+      out);
+
+    var response = parseResponse(out);
+    assertThat(response.error().message()).contains("IllegalStateException");
+  }
+
+  @Test
+  void should_skip_blank_lines_then_respond() {
+    var response = respondTo("""
+      
+      {"jsonrpc":"2.0","id":4,"method":"initialize"}
+      """, "missing token");
+
+    assertThat(response.id()).isEqualTo(4);
+    assertThat(response.error().message()).isEqualTo("missing token");
+  }
+
+  @Test
+  void should_complete_when_writing_the_error_fails() {
+    var failingOut = new OutputStream() {
+      @Override
+      public void write(int b) throws IOException {
+        throw new IOException("broken pipe");
+      }
+    };
+
+    assertThatCode(() -> StdioInitializeErrorReporter.respondToInitialize(
+      "auth failed",
+      stream("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n"),
+      failingOut,
+      Duration.ofSeconds(2)))
+      .doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_stop_waiting_after_timeout() {
+    var out = new ByteArrayOutputStream();
+
+    StdioInitializeErrorReporter.respondToInitialize(
+      "auth failed",
+      blockingInput(),
+      out,
+      Duration.ofMillis(100));
+
+    assertThat(out.size()).isZero();
+  }
+
+  @Test
+  void should_preserve_interrupt_status_when_waiting_is_interrupted() throws InterruptedException {
+    var worker = Thread.ofPlatform().start(() ->
+      StdioInitializeErrorReporter.respondToInitialize(
+        "auth failed",
+        blockingInput(),
+        new ByteArrayOutputStream(),
+        Duration.ofSeconds(30)));
+
+    Thread.sleep(50);
+    worker.interrupt();
+    worker.join(Duration.ofSeconds(2));
+
+    assertThat(worker.isAlive()).isFalse();
+  }
+
+  private static McpSchema.JSONRPCResponse respondTo(String input, String errorMessage) {
+    var out = new ByteArrayOutputStream();
+    StdioInitializeErrorReporter.respondToInitialize(errorMessage, stream(input), out, Duration.ofSeconds(2));
+    return parseResponse(out);
+  }
+
+  private static ByteArrayInputStream stream(String input) {
+    return new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static InputStream blockingInput() {
+    return new InputStream() {
+      @Override
+      public int read() throws IOException {
+        try {
+          Thread.sleep(60_000);
+          return -1;
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("interrupted", e);
+        }
+      }
+    };
+  }
+
+  private static McpSchema.JSONRPCResponse parseResponse(ByteArrayOutputStream out) {
+    try {
+      var parsed = McpSchema.deserializeJsonRpcMessage(McpJsonMappers.DEFAULT, out.toString(StandardCharsets.UTF_8).trim());
+      assertThat(parsed).isInstanceOf(McpSchema.JSONRPCResponse.class);
+      return (McpSchema.JSONRPCResponse) parsed;
+    } catch (IOException e) {
+      throw new AssertionError("Failed to parse JSON-RPC response", e);
+    }
+  }
+}


### PR DESCRIPTION
<img width="463" height="380" alt="image" src="https://github.com/user-attachments/assets/d7ae65bf-94a1-46f9-8435-75f29879c63e" />

## Summary
- On stdio startup failure (missing token, URL, storage path, …), wait for the client’s MCP `initialize` request and reply with a JSON-RPC error instead of exiting silently.
- Clients can show the real cause instead of `Connection closed`.
- HTTP/HTTPS launches skip this stdin wait; they only log the failure.
- Uses existing MCP JSON-RPC types (`McpSchema` / `McpJsonMappers`), not a second protocol stack.

## Test plan
- [x] Stdio with missing `SONARQUBE_TOKEN`: client receives an `initialize` error containing the token message
- [x] HTTP/HTTPS startup failure: process does not block on stdin

----
## Summary by Gitar

- **Error reporting:**
    - Added `StdioInitializeErrorReporter` to catch startup failures and reply to `initialize` with JSON-RPC errors instead of closing connection
    - Created `JsonRpcErrorResponses` utility for generating JSON-RPC 2.0 error payloads with code `-32000`
    - Updated `SonarQubeMcpServer` main method to catch runtime exceptions and report initialization errors via stdio

<sub>This will update automatically on new commits.</sub>