### PR TITLE
MCP-611 Make McpServerLaunchConfiguration and McpClientManager final

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
@@ -38,7 +38,7 @@ import org.sonarsource.sonarqube.mcp.transport.McpJsonMappers;
  * This allows the SonarQube MCP server to act as a client to other MCP servers
  * and expose their tools through the SonarQube MCP server.
  */
-public class McpClientManager {
+public final class McpClientManager {
   
   private static final McpLogger LOG = McpLogger.getInstance();
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(

--- a/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/client/McpClientManager.java
@@ -233,7 +233,7 @@ public final class McpClientManager {
    * Builds the environment variables map for a proxied server by combining explicit values from config and inherited values from parent environment.
    */
   @VisibleForTesting
-  Map<String, String> buildEnvironmentVariables(ProxiedMcpServerConfig config, Map<String, String> parentEnv) {
+  static Map<String, String> buildEnvironmentVariables(ProxiedMcpServerConfig config, Map<String, String> parentEnv) {
     var filteredEnv = new HashMap<String, String>();
     
     // Add explicit values from config

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -34,7 +34,7 @@ import org.sonarsource.sonarqube.mcp.tools.ToolCategory;
 
 import static java.util.Objects.requireNonNull;
 
-public class McpServerLaunchConfiguration {
+public final class McpServerLaunchConfiguration {
 
   private static final String APP_NAME = "SonarQube MCP Server";
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/configuration/McpServerLaunchConfiguration.java
@@ -271,7 +271,7 @@ public final class McpServerLaunchConfiguration {
     return userAgent;
   }
 
-  public String getAppName() {
+  public static String getAppName() {
     return APP_NAME;
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/slcore/BackendService.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/slcore/BackendService.java
@@ -88,7 +88,7 @@ public class BackendService {
     this.logFilePath = mcpConfiguration.getLogFilePath();
     this.appVersion = mcpConfiguration.getAppVersion();
     this.userAgent = mcpConfiguration.getUserAgent();
-    this.appName = mcpConfiguration.getAppName();
+    this.appName = McpServerLaunchConfiguration.getAppName();
     this.isTelemetryEnabled = mcpConfiguration.isTelemetryEnabled();
     this.isFileLoggingDisabled = mcpConfiguration.isFileLoggingDisabled();
     if (!mcpConfiguration.isHttpEnabled()) {

--- a/src/test/java/org/sonarsource/sonarqube/mcp/client/McpClientManagerTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/client/McpClientManagerTest.java
@@ -116,13 +116,12 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_include_explicit_values_from_config() {
-    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(),
       Map.of("EXPLICIT_VAR1", "value1", "EXPLICIT_VAR2", "value2"),
       List.of(), Set.of(TransportMode.STDIO));
     var parentEnv = Map.of("PARENT_VAR", "parent_value");
 
-    var result = manager.buildEnvironmentVariables(config, parentEnv);
+    var result = McpClientManager.buildEnvironmentVariables(config, parentEnv);
 
     assertThat(result)
       .hasSize(2)
@@ -133,7 +132,6 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_inherit_variables_from_parent() {
-    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(),
       Map.of(),
       List.of("INHERITED_VAR1", "INHERITED_VAR2"),
@@ -144,7 +142,7 @@ class McpClientManagerTest {
       "NOT_INHERITED", "should_not_appear"
     );
 
-    var result = manager.buildEnvironmentVariables(config, parentEnv);
+    var result = McpClientManager.buildEnvironmentVariables(config, parentEnv);
 
     assertThat(result)
       .hasSize(2)
@@ -155,14 +153,13 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_prioritize_explicit_values_over_inherited() {
-    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(),
       Map.of("OVERRIDE_VAR", "explicit_value"),
       List.of("OVERRIDE_VAR"),
       Set.of(TransportMode.STDIO));
     var parentEnv = Map.of("OVERRIDE_VAR", "parent_value");
 
-    var result = manager.buildEnvironmentVariables(config, parentEnv);
+    var result = McpClientManager.buildEnvironmentVariables(config, parentEnv);
 
     assertThat(result)
       .hasSize(1)
@@ -198,14 +195,13 @@ class McpClientManagerTest {
 
   @Test
   void buildEnvironmentVariables_should_skip_inherited_var_not_in_parent() {
-    var manager = new McpClientManager(List.of(), UUID.randomUUID().toString());
     var config = new ProxiedMcpServerConfig("server", "cmd", List.of(),
       Map.of(),
       List.of("MISSING_VAR", "EXISTING_VAR"),
       Set.of(TransportMode.STDIO));
     var parentEnv = Map.of("EXISTING_VAR", "existing_value");
 
-    var result = manager.buildEnvironmentVariables(config, parentEnv);
+    var result = McpClientManager.buildEnvironmentVariables(config, parentEnv);
 
     assertThat(result)
       .hasSize(1)


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactoring:**
    - Made `McpClientManager` and `McpServerLaunchConfiguration` classes final
    - Updated `getAppName` to be a static method and adjusted `BackendService` accordingly
    - Made `buildEnvironmentVariables` static in `McpClientManager` and updated its unit tests

<sub>This will update automatically on new commits.</sub>