### PR TITLE
MCP-588 Add comment parameter to change_sonar_issue_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,6 +1071,7 @@ Omit `-Djavax.net.ssl.keyStorePassword` if the keystore has no passphrase.
 - **change_sonar_issue_status** - Change the status of a SonarQube issue to "accept", "falsepositive" or to "reopen" an issue.
   - `key` - Issue key - _Required String_
   - `status` - New issue's status - _Required Enum {"accept", "falsepositive", "reopen"}_
+  - `comment` - Optional comment explaining the status change - _String_
 
 
 - **search_sonar_issues_in_projects** - Search for SonarQube issues in my organization's projects.

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/issues/IssuesApi.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/issues/IssuesApi.java
@@ -30,6 +30,8 @@ import static org.sonarsource.sonarlint.core.serverapi.UrlUtils.urlEncode;
 public class IssuesApi {
 
   public static final String SEARCH_PATH = "/api/issues/search";
+  public static final String DO_TRANSITION_PATH = "/api/issues/do_transition";
+  public static final String ADD_COMMENT_PATH = "/api/issues/add_comment";
 
   private final ServerApiHelper helper;
 
@@ -59,7 +61,14 @@ public class IssuesApi {
 
   public void doTransition(String issueKey, Transition transition) {
     var body = "issue=" + urlEncode(issueKey) + "&transition=" + urlEncode(transition.getStatus());
-    try (var ignored = helper.post("/api/issues/do_transition", FORM_URL_ENCODED_CONTENT_TYPE, body)) {
+    try (var ignored = helper.post(DO_TRANSITION_PATH, FORM_URL_ENCODED_CONTENT_TYPE, body)) {
+      // Response is closed automatically
+    }
+  }
+
+  public void addComment(String issueKey, String text) {
+    var body = "issue=" + urlEncode(issueKey) + "&text=" + urlEncode(text);
+    try (var ignored = helper.post(ADD_COMMENT_PATH, FORM_URL_ENCODED_CONTENT_TYPE, body)) {
       // Response is closed automatically
     }
   }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/ChangeIssueStatusTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/issues/ChangeIssueStatusTool.java
@@ -27,7 +27,8 @@ public class ChangeIssueStatusTool extends Tool {
   public static final String TOOL_NAME = "change_sonar_issue_status";
   public static final String KEY_PROPERTY = "key";
   public static final String STATUS_PROPERTY = "status";
-  
+  public static final String COMMENT_PROPERTY = "comment";
+
   private static final String[] VALID_STATUSES = {"accept", "falsepositive", "reopen"};
 
   private final ServerApiProvider serverApiProvider;
@@ -38,9 +39,11 @@ public class ChangeIssueStatusTool extends Tool {
       .setTitle("Change SonarQube Issue Status")
       .setDescription("""
         Change the status of an issue. This tool can be used to change the status of an issue to "accept", "falsepositive" or to "reopen" an issue.
-        An example request could be: I would like to accept the issue having the key "AX-HMISMFixnZED\"""")
+        An example request could be: I would like to accept the issue having the key "AX-HMISMFixnZED"
+        You can optionally add a comment to explain your triage decision.""")
       .addRequiredStringProperty(KEY_PROPERTY, "The key of the issue which status should be changed")
       .addRequiredEnumProperty(STATUS_PROPERTY, VALID_STATUSES, "The new status of the issue")
+      .addStringProperty(COMMENT_PROPERTY, "An optional comment explaining the status change")
       .build(),
       ToolCategory.ISSUES);
     this.serverApiProvider = serverApiProvider;
@@ -50,12 +53,24 @@ public class ChangeIssueStatusTool extends Tool {
   public Tool.Result execute(Tool.Arguments arguments) {
     var key = arguments.getStringOrThrow(KEY_PROPERTY);
     var statusString = arguments.getEnumOrThrow(STATUS_PROPERTY, VALID_STATUSES);
+    var comment = arguments.getOptionalString(COMMENT_PROPERTY);
     var status = Transition.fromStatus(statusString);
     if (status.isEmpty()) {
       return Tool.Result.failure("Status is unknown: " + statusString);
     }
 
-    serverApiProvider.get().issuesApi().doTransition(key, status.get());
+    var issuesApi = serverApiProvider.get().issuesApi();
+    issuesApi.doTransition(key, status.get());
+
+    if (comment != null && !comment.isBlank()) {
+      try {
+        issuesApi.addComment(key, comment);
+      } catch (Exception e) {
+        return Tool.Result.failure("The issue status was changed to '" + statusString
+          + "', but the comment could not be added: " + e.getMessage());
+      }
+    }
+
     var message = "The issue status was successfully changed.";
     var response = new ChangeIssueStatusToolResponse(true, message, key, statusString);
     return Tool.Result.success(response);

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/ChangeIssuesStatusToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/ChangeIssuesStatusToolTests.java
@@ -50,7 +50,10 @@ class ChangeIssuesStatusToolTests {
         "status", Map.of(
           "type", "string",
           "description", "The new status of the issue",
-          "enum", List.of("accept", "falsepositive", "reopen"))),
+          "enum", List.of("accept", "falsepositive", "reopen")),
+        "comment", Map.of(
+          "description", "An optional comment explaining the status change",
+          "type", "string")),
       "required", List.of("key", "status"),
       "additionalProperties", false));
   }
@@ -221,6 +224,79 @@ class ChangeIssuesStatusToolTests {
         }""");
       assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
         .contains(new ReceivedRequest("Bearer token", "issue=k&transition=reopen"));
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_change_the_status_and_add_a_comment(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(post("/api/issues/do_transition").willReturn(ok()));
+      harness.getMockSonarQubeServer().stubFor(post("/api/issues/add_comment").willReturn(ok()));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      var result = mcpClient.callTool(
+        ChangeIssueStatusTool.TOOL_NAME,
+        Map.of("key", "k",
+          "status", "accept",
+          "comment", "Not reachable from any entrypoint"));
+
+      assertResultEquals(result, """
+        {
+          "success" : true,
+          "message" : "The issue status was successfully changed.",
+          "issueKey" : "k",
+          "newStatus" : "accept"
+        }""");
+      assertThat(harness.getMockSonarQubeServer().getReceivedRequests())
+        .contains(
+          new ReceivedRequest("Bearer token", "issue=k&transition=accept"),
+          new ReceivedRequest("Bearer token", "issue=k&text=Not+reachable+from+any+entrypoint"));
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_not_call_add_comment_when_no_comment_is_provided(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(post("/api/issues/do_transition").willReturn(ok()));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      mcpClient.callTool(
+        ChangeIssueStatusTool.TOOL_NAME,
+        Map.of("key", "k",
+          "status", "accept"));
+
+      assertThat(harness.getMockSonarQubeServer().countRequestsContaining("/api/issues/add_comment")).isZero();
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_not_call_add_comment_when_comment_is_blank(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(post("/api/issues/do_transition").willReturn(ok()));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      mcpClient.callTool(
+        ChangeIssueStatusTool.TOOL_NAME,
+        Map.of("key", "k",
+          "status", "accept",
+          "comment", "   "));
+
+      assertThat(harness.getMockSonarQubeServer().countRequestsContaining("/api/issues/add_comment")).isZero();
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_report_a_partial_failure_when_the_comment_cannot_be_added(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(post("/api/issues/do_transition").willReturn(ok()));
+      harness.getMockSonarQubeServer().stubFor(post("/api/issues/add_comment").willReturn(aResponse().withStatus(403)));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"));
+
+      var result = mcpClient.callTool(
+        ChangeIssueStatusTool.TOOL_NAME,
+        Map.of("key", "k",
+          "status", "accept",
+          "comment", "Not reachable from any entrypoint"));
+
+      assertThat(result).isEqualTo(McpSchema.CallToolResult.builder().isError(true)
+        .addTextContent("The issue status was changed to 'accept', but the comment could not be added: SonarQube answered with Forbidden")
+        .build());
     }
 
   }

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/ChangeIssuesStatusToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/issues/ChangeIssuesStatusToolTests.java
@@ -258,11 +258,18 @@ class ChangeIssuesStatusToolTests {
       var mcpClient = harness.newClient(Map.of(
         "SONARQUBE_ORG", "org"));
 
-      mcpClient.callTool(
+      var result = mcpClient.callTool(
         ChangeIssueStatusTool.TOOL_NAME,
         Map.of("key", "k",
           "status", "accept"));
 
+      assertResultEquals(result, """
+        {
+          "success" : true,
+          "message" : "The issue status was successfully changed.",
+          "issueKey" : "k",
+          "newStatus" : "accept"
+        }""");
       assertThat(harness.getMockSonarQubeServer().countRequestsContaining("/api/issues/add_comment")).isZero();
     }
 
@@ -272,12 +279,19 @@ class ChangeIssuesStatusToolTests {
       var mcpClient = harness.newClient(Map.of(
         "SONARQUBE_ORG", "org"));
 
-      mcpClient.callTool(
+      var result = mcpClient.callTool(
         ChangeIssueStatusTool.TOOL_NAME,
         Map.of("key", "k",
           "status", "accept",
           "comment", "   "));
 
+      assertResultEquals(result, """
+        {
+          "success" : true,
+          "message" : "The issue status was successfully changed.",
+          "issueKey" : "k",
+          "newStatus" : "accept"
+        }""");
       assertThat(harness.getMockSonarQubeServer().countRequestsContaining("/api/issues/add_comment")).isZero();
     }
 


### PR DESCRIPTION
  ### What
  Adds an optional `comment` parameter to `change_sonar_issue_status`, matching the existing `comment` support on `change_sonar_security_hotspot_status`.

  ### Why
  `change_sonar_issue_status` had no way to persist a triage justification (e.g. "not reachable from any entrypoint"). Hotspots already support this; issues didn't.
  
  ### How
  `POST /api/issues/do_transition` only accepts `issue` and `transition` — it has no `comment` param. Persisting a comment requires a separate call to `POST /api/issues/add_comment` (`issue`, `text`), which the server didn't implement yet.

  The tool now:
  1. Calls `do_transition` as before.
  2. If a `comment` was provided, calls the new `IssuesApi.addComment(...)`.
  3. If the transition succeeds but the comment call fails, the tool returns a failure explicitly stating the status *was* changed but the comment was not — so the caller doesn't retry the whole transition.

  Verified `add_comment` has an identical contract (`issue`, `text`) on both SonarQube Cloud and SonarQube Server, so no cloud/server branching is needed (consistent with the rest of `IssuesApi`).

  ### Changes
  - `IssuesApi.java` — new `addComment`, extracted `DO_TRANSITION_PATH`/`ADD_COMMENT_PATH` constants
  - `ChangeIssueStatusTool.java` — optional `comment` schema property, two-call execution with partial-failure handling
  - `ChangeIssuesStatusToolTests.java` — schema update + tests for comment success, no-comment, and partial-failure cases
  - `README.md` — documented the new `comment` parameter



----
## Summary by Gitar

- **New Feature:**
    - Added optional `comment` parameter to `change_sonar_issue_status` tool to explain triage decisions

<sub>This will update automatically on new commits.</sub>