### PR TITLE
MCP-614 Preserve New Code period values in get_component_measures

### DIFF
--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/measures/response/ComponentMeasuresResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/measures/response/ComponentMeasuresResponse.java
@@ -24,7 +24,8 @@ public record ComponentMeasuresResponse(Component component, List<Metric> metric
   public record Component(String key, String name, String description, String qualifier, String language, String path, List<Measure> measures) {
   }
 
-  public record Measure(String metric, @Nullable String value, @Nullable List<MeasurePeriod> periods, @Nullable MeasurePeriod period) {
+  public record Measure(String metric, @Nullable String value, @Nullable Boolean bestValue,
+    @Nullable List<MeasurePeriod> periods, @Nullable MeasurePeriod period) {
 
     @Nullable
     public MeasurePeriod newCodePeriod() {
@@ -34,10 +35,13 @@ public record ComponentMeasuresResponse(Component component, List<Metric> metric
       if (periods == null || periods.isEmpty()) {
         return null;
       }
-      return periods.stream()
-        .filter(p -> p.index() != null && p.index() == 1)
-        .findFirst()
-        .orElse(periods.getFirst());
+      var indexedPeriod = periods.stream()
+        .filter(p -> Integer.valueOf(1).equals(p.index()))
+        .findFirst();
+      if (indexedPeriod.isPresent()) {
+        return indexedPeriod.get();
+      }
+      return periods.size() == 1 ? periods.getFirst() : null;
     }
   }
 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/measures/response/ComponentMeasuresResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/serverapi/measures/response/ComponentMeasuresResponse.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.sonarqube.mcp.serverapi.measures.response;
 
+import jakarta.annotation.Nullable;
 import java.util.List;
 
 public record ComponentMeasuresResponse(Component component, List<Metric> metrics, List<Period> periods) {
@@ -23,10 +24,24 @@ public record ComponentMeasuresResponse(Component component, List<Metric> metric
   public record Component(String key, String name, String description, String qualifier, String language, String path, List<Measure> measures) {
   }
 
-  public record Measure(String metric, String value, List<MeasurePeriod> periods) {
+  public record Measure(String metric, @Nullable String value, @Nullable List<MeasurePeriod> periods, @Nullable MeasurePeriod period) {
+
+    @Nullable
+    public MeasurePeriod newCodePeriod() {
+      if (period != null) {
+        return period;
+      }
+      if (periods == null || periods.isEmpty()) {
+        return null;
+      }
+      return periods.stream()
+        .filter(p -> p.index() != null && p.index() == 1)
+        .findFirst()
+        .orElse(periods.getFirst());
+    }
   }
 
-  public record MeasurePeriod(int index, String value) {
+  public record MeasurePeriod(@Nullable Integer index, @Nullable String value, @Nullable Boolean bestValue) {
   }
 
   public record Metric(String key, String name, String description, String domain, String type, 

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
@@ -108,7 +108,7 @@ public class GetComponentMeasuresTool extends Tool {
 
   private static GetComponentMeasuresToolResponse.Measure toToolMeasure(ComponentMeasuresResponse.Measure measure) {
     if (measure.value() != null) {
-      return new GetComponentMeasuresToolResponse.Measure(measure.metric(), measure.value(), null, null);
+      return new GetComponentMeasuresToolResponse.Measure(measure.metric(), measure.value(), null, measure.bestValue());
     }
     var period = measure.newCodePeriod();
     if (period == null) {

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresTool.java
@@ -89,7 +89,7 @@ public class GetComponentMeasuresTool extends Tool {
     
     var measures = (comp.measures() != null) ?
       comp.measures().stream()
-        .map(m -> new GetComponentMeasuresToolResponse.Measure(m.metric(), m.value()))
+        .map(GetComponentMeasuresTool::toToolMeasure)
         .toList()
       : List.<GetComponentMeasuresToolResponse.Measure>of();
     
@@ -104,6 +104,17 @@ public class GetComponentMeasuresTool extends Tool {
     }
 
     return new GetComponentMeasuresToolResponse(componentResponse, measures, metrics);
+  }
+
+  private static GetComponentMeasuresToolResponse.Measure toToolMeasure(ComponentMeasuresResponse.Measure measure) {
+    if (measure.value() != null) {
+      return new GetComponentMeasuresToolResponse.Measure(measure.metric(), measure.value(), null, null);
+    }
+    var period = measure.newCodePeriod();
+    if (period == null) {
+      return new GetComponentMeasuresToolResponse.Measure(measure.metric(), null, null, null);
+    }
+    return new GetComponentMeasuresToolResponse.Measure(measure.metric(), period.value(), period.index(), period.bestValue());
   }
 
 }

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolResponse.java
@@ -40,7 +40,7 @@ public record GetComponentMeasuresToolResponse(
   public record Measure(
     @JsonPropertyDescription("Metric key") String metric,
     @JsonPropertyDescription("Measure value") @Nullable String value,
-    @JsonPropertyDescription("New Code period index when the value comes from a period") @Nullable Integer period,
+    @JsonPropertyDescription("New Code period index, present when value is a New Code metric") @Nullable Integer period,
     @JsonPropertyDescription("Whether this is the metric's best possible value") @Nullable Boolean bestValue
   ) {}
   

--- a/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolResponse.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolResponse.java
@@ -39,7 +39,9 @@ public record GetComponentMeasuresToolResponse(
   
   public record Measure(
     @JsonPropertyDescription("Metric key") String metric,
-    @JsonPropertyDescription("Measure value") @Nullable String value
+    @JsonPropertyDescription("Measure value") @Nullable String value,
+    @JsonPropertyDescription("New Code period index when the value comes from a period") @Nullable Integer period,
+    @JsonPropertyDescription("Whether this is the metric's best possible value") @Nullable Boolean bestValue
   ) {}
   
   public record Metric(

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
@@ -103,7 +103,7 @@ class GetComponentMeasuresToolTests {
                      },
                      "period":{
                         "type":"integer",
-                        "description":"New Code period index when the value comes from a period"
+                        "description":"New Code period index, present when value is a New Code metric"
                      },
                      "value":{
                         "type":"string",
@@ -273,7 +273,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -281,7 +282,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -342,7 +344,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -350,7 +353,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -497,6 +501,60 @@ class GetComponentMeasuresToolTests {
     }
 
     @SonarQubeMcpServerTest
+    void it_should_ignore_periods_that_are_not_the_new_code_period(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH
+          + "?component=" + urlEncode("MY_PROJECT")
+          + "&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes("""
+          {
+            "component": {
+              "key": "MY_PROJECT",
+              "name": "My Project",
+              "qualifier": "TRK",
+              "measures": [
+                {
+                  "metric": "new_violations",
+                  "periods": [
+                    {
+                      "index": 2,
+                      "value": "9",
+                      "bestValue": false
+                    },
+                    {
+                      "index": 3,
+                      "value": "4",
+                      "bestValue": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          """.getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"
+      ));
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT"));
+
+      assertResultEquals(result, """
+        {
+          "component" : {
+            "key" : "MY_PROJECT",
+            "name" : "My Project",
+            "qualifier" : "TRK"
+          },
+          "measures" : [ {
+            "metric" : "new_violations"
+          } ]
+        }""");
+    }
+
+    @SonarQubeMcpServerTest
     void it_should_fetch_component_measures_with_metric_keys(SonarQubeMcpServerTestHarness harness) {
       harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH + "?component=" + urlEncode("MY_PROJECT:ElementImpl.java") + "&metricKeys=ncloc,complexity&additionalFields=metrics")
         .willReturn(aResponse().withResponseBody(
@@ -525,7 +583,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -533,7 +592,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -594,7 +654,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -602,7 +663,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -767,7 +829,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "coverage",
-            "value" : "91.9"
+            "value" : "91.9",
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "53717"
@@ -863,7 +926,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -871,7 +935,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -932,7 +997,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -940,7 +1006,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -1023,7 +1090,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -1031,7 +1099,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -1090,7 +1159,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "complexity",
-            "value" : "12"
+            "value" : "12",
+            "bestValue" : false
           }, {
             "metric" : "new_violations",
             "value" : "25",
@@ -1098,7 +1168,8 @@ class GetComponentMeasuresToolTests {
             "bestValue" : false
           }, {
             "metric" : "ncloc",
-            "value" : "114"
+            "value" : "114",
+            "bestValue" : false
           } ],
           "metrics" : [ {
             "key" : "complexity",
@@ -1259,7 +1330,8 @@ class GetComponentMeasuresToolTests {
           },
           "measures" : [ {
             "metric" : "coverage",
-            "value" : "91.9"
+            "value" : "91.9",
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "53717"

--- a/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/tools/measures/GetComponentMeasuresToolTests.java
@@ -93,9 +93,17 @@ class GetComponentMeasuresToolTests {
                "items":{
                   "type":"object",
                   "properties":{
+                     "bestValue":{
+                        "type":"boolean",
+                        "description":"Whether this is the metric's best possible value"
+                     },
                      "metric":{
                         "type":"string",
                         "description":"Metric key"
+                     },
+                     "period":{
+                        "type":"integer",
+                        "description":"New Code period index when the value comes from a period"
                      },
                      "value":{
                         "type":"string",
@@ -267,7 +275,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -333,7 +344,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -369,6 +383,120 @@ class GetComponentMeasuresToolTests {
     }
 
     @SonarQubeMcpServerTest
+    void it_should_expose_new_code_period_values_on_branch(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH
+          + "?component=" + urlEncode("MY_PROJECT")
+          + "&branch=master"
+          + "&metricKeys=new_blocker_violations,new_critical_violations,new_major_violations,new_minor_violations"
+          + "&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes(generateNewCodeViolationsOnBranchResponse().getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"
+      ));
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(
+          GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT",
+          GetComponentMeasuresTool.BRANCH_PROPERTY, "master",
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY,
+          List.of("new_blocker_violations", "new_critical_violations", "new_major_violations", "new_minor_violations")
+        ));
+
+      assertResultEquals(result, expectedNewCodeViolationsOnBranchResult());
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_expose_new_code_value_from_singular_period(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH
+          + "?component=" + urlEncode("MY_PROJECT")
+          + "&branch=master"
+          + "&metricKeys=new_major_violations"
+          + "&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes(generateSingularPeriodResponse().getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"
+      ));
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(
+          GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT",
+          GetComponentMeasuresTool.BRANCH_PROPERTY, "master",
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY, List.of("new_major_violations")
+        ));
+
+      assertResultEquals(result, """
+        {
+          "component" : {
+            "key" : "MY_PROJECT",
+            "name" : "My Project",
+            "qualifier" : "TRK"
+          },
+          "measures" : [ {
+            "metric" : "new_major_violations",
+            "value" : "2",
+            "period" : 1,
+            "bestValue" : false
+          } ]
+        }""");
+    }
+
+    @SonarQubeMcpServerTest
+    void it_should_prefer_top_level_value_over_periods(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH
+          + "?component=" + urlEncode("MY_PROJECT")
+          + "&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes("""
+          {
+            "component": {
+              "key": "MY_PROJECT",
+              "name": "My Project",
+              "qualifier": "TRK",
+              "measures": [
+                {
+                  "metric": "ncloc",
+                  "value": "114",
+                  "periods": [
+                    {
+                      "index": 1,
+                      "value": "25"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          """.getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient(Map.of(
+        "SONARQUBE_ORG", "org"
+      ));
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT"));
+
+      assertResultEquals(result, """
+        {
+          "component" : {
+            "key" : "MY_PROJECT",
+            "name" : "My Project",
+            "qualifier" : "TRK"
+          },
+          "measures" : [ {
+            "metric" : "ncloc",
+            "value" : "114"
+          } ]
+        }""");
+    }
+
+    @SonarQubeMcpServerTest
     void it_should_fetch_component_measures_with_metric_keys(SonarQubeMcpServerTestHarness harness) {
       harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH + "?component=" + urlEncode("MY_PROJECT:ElementImpl.java") + "&metricKeys=ncloc,complexity&additionalFields=metrics")
         .willReturn(aResponse().withResponseBody(
@@ -399,7 +527,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -465,7 +596,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -731,7 +865,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -797,7 +934,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -833,6 +973,30 @@ class GetComponentMeasuresToolTests {
     }
 
     @SonarQubeMcpServerTest
+    void it_should_expose_new_code_period_values_on_branch(SonarQubeMcpServerTestHarness harness) {
+      harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH
+          + "?component=" + urlEncode("MY_PROJECT")
+          + "&branch=master"
+          + "&metricKeys=new_blocker_violations,new_critical_violations,new_major_violations,new_minor_violations"
+          + "&additionalFields=metrics")
+        .willReturn(aResponse().withResponseBody(
+          Body.fromJsonBytes(generateNewCodeViolationsOnBranchResponse().getBytes(StandardCharsets.UTF_8))
+        )));
+      var mcpClient = harness.newClient();
+
+      var result = mcpClient.callTool(
+        GetComponentMeasuresTool.TOOL_NAME,
+        Map.of(
+          GetComponentMeasuresTool.PROJECT_KEY_PROPERTY, "MY_PROJECT",
+          GetComponentMeasuresTool.BRANCH_PROPERTY, "master",
+          GetComponentMeasuresTool.METRIC_KEYS_PROPERTY,
+          List.of("new_blocker_violations", "new_critical_violations", "new_major_violations", "new_minor_violations")
+        ));
+
+      assertResultEquals(result, expectedNewCodeViolationsOnBranchResult());
+    }
+
+    @SonarQubeMcpServerTest
     void it_should_fetch_component_measures_with_metric_keys(SonarQubeMcpServerTestHarness harness) {
       harness.getMockSonarQubeServer().stubFor(get(MeasuresApi.COMPONENT_PATH + "?component=" + urlEncode("MY_PROJECT:ElementImpl.java") + "&metricKeys=ncloc,complexity&additionalFields=metrics")
         .willReturn(aResponse().withResponseBody(
@@ -861,7 +1025,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -925,7 +1092,10 @@ class GetComponentMeasuresToolTests {
             "metric" : "complexity",
             "value" : "12"
           }, {
-            "metric" : "new_violations"
+            "metric" : "new_violations",
+            "value" : "25",
+            "period" : 1,
+            "bestValue" : false
           }, {
             "metric" : "ncloc",
             "value" : "114"
@@ -1192,6 +1362,114 @@ class GetComponentMeasuresToolTests {
             "parameter": "1.0-SNAPSHOT"
           }
         ]
+      }
+      """;
+  }
+
+  private static String generateNewCodeViolationsOnBranchResponse() {
+    return """
+      {
+        "component": {
+          "key": "MY_PROJECT",
+          "name": "My Project",
+          "qualifier": "TRK",
+          "measures": [
+            {
+              "metric": "new_major_violations",
+              "periods": [
+                {
+                  "index": 1,
+                  "value": "2",
+                  "bestValue": false
+                }
+              ]
+            },
+            {
+              "metric": "new_minor_violations",
+              "periods": [
+                {
+                  "index": 1,
+                  "value": "0",
+                  "bestValue": true
+                }
+              ]
+            },
+            {
+              "metric": "new_critical_violations",
+              "periods": [
+                {
+                  "index": 1,
+                  "value": "0",
+                  "bestValue": true
+                }
+              ]
+            },
+            {
+              "metric": "new_blocker_violations",
+              "periods": [
+                {
+                  "index": 1,
+                  "value": "0",
+                  "bestValue": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+      """;
+  }
+
+  private static String expectedNewCodeViolationsOnBranchResult() {
+    return """
+      {
+        "component" : {
+          "key" : "MY_PROJECT",
+          "name" : "My Project",
+          "qualifier" : "TRK"
+        },
+        "measures" : [ {
+          "metric" : "new_major_violations",
+          "value" : "2",
+          "period" : 1,
+          "bestValue" : false
+        }, {
+          "metric" : "new_minor_violations",
+          "value" : "0",
+          "period" : 1,
+          "bestValue" : true
+        }, {
+          "metric" : "new_critical_violations",
+          "value" : "0",
+          "period" : 1,
+          "bestValue" : true
+        }, {
+          "metric" : "new_blocker_violations",
+          "value" : "0",
+          "period" : 1,
+          "bestValue" : true
+        } ]
+      }""";
+  }
+
+  private static String generateSingularPeriodResponse() {
+    return """
+      {
+        "component": {
+          "key": "MY_PROJECT",
+          "name": "My Project",
+          "qualifier": "TRK",
+          "measures": [
+            {
+              "metric": "new_major_violations",
+              "period": {
+                "index": 1,
+                "value": "2",
+                "bestValue": false
+              }
+            }
+          ]
+        }
       }
       """;
   }


### PR DESCRIPTION
## Problem

`get_component_measures` dropped New Code metric values on branches. SonarQube returns those measures under `measures[].periods[]` (or the newer singular `period` object) rather than a top-level `value`. The tool only copied `measure.value`, so agents received metrics with no usable value.

Reported in [community thread 186322](https://community.sonarsource.com/t/sonarqube-mcp-measure-tool-drops-periods-values-for-new-code-metrics-on-branches/186322). Jira: [MCP-614](https://sonarsource.atlassian.net/browse/MCP-614).

## Fix

Normalize New Code period data into the existing measure shape:

- Keep top-level `measure.value` when present (overall metrics)
- Otherwise read `measure.period`, then `measure.periods[index=1]`, then a single unlabeled period
- Expose `value`, `period`, and `bestValue` for both overall and New Code measures
- Do not fall back to an arbitrary non-New-Code period

## Tests

- Branch New Code `periods[]` fixture matching the community reproduction (`new_major_violations=2`, others `0`)
- Singular `period` object (newer API shape)
- Top-level `value` still wins when both forms are present
- Overall `bestValue` is forwarded
- Periods that are not the New Code period are ignored
- Tested on both SQS and SQC with live MCP


[MCP-614]: https://sonarsource.atlassian.net/browse/MCP-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ