### PR TITLE
MCP-619 Bump context augmentation from 0.19.0.3620 to 0.20.0.4545

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apk upgrade --no-cache && \
 
 ARG TARGETARCH
 # Keep in sync with sonarContextAugmentationVersion in gradle.properties
-ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.19.0.3620
+ARG SONAR_CONTEXT_AUGMENTATION_VERSION=0.20.0.4545
 
 RUN case "$TARGETARCH" in \
         amd64) ARCH="x64" ;; \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.27-SNAPSHOT
-sonarContextAugmentationVersion=0.19.0.3620
+sonarContextAugmentationVersion=0.20.0.4545
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.daemon=true


### PR DESCRIPTION
## Summary
- Bumps `sonarContextAugmentationVersion` in `gradle.properties` and the `SONAR_CONTEXT_AUGMENTATION_VERSION` build arg in `Dockerfile` to `0.20.0.4545`.
