### PR TITLE
MCP-604 Resolve SLCORE user home and work dir from STORAGE_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apk upgrade --no-cache && \
         nodejs=~24 \
         sudo && \
         addgroup -S appgroup && adduser -S appuser -G appgroup && \
-        mkdir -p /home/appuser/.sonarlint /app/storage && \
+        mkdir -p /app/storage && \
         chown -R appuser:appgroup /home/appuser /app/storage && \
         echo "appuser ALL=(ALL) NOPASSWD: /usr/sbin/update-ca-certificates" > /etc/sudoers.d/appuser && \
         chmod 0440 /etc/sudoers.d/appuser

--- a/src/main/java/org/sonarsource/sonarqube/mcp/slcore/BackendService.java
+++ b/src/main/java/org/sonarsource/sonarqube/mcp/slcore/BackendService.java
@@ -25,7 +25,6 @@ import java.io.PipedOutputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -144,7 +143,11 @@ public class BackendService {
   }
 
   public Path getWorkDir() {
-    return Paths.get(System.getProperty("user.home")).resolve(".sonarlint");
+    return getSonarLintUserHome().resolve("work");
+  }
+
+  private Path getSonarLintUserHome() {
+    return storagePath.resolve(".sonarlint");
   }
 
   public void initialize(AnalyzersAndLanguagesEnabled analyzers) {
@@ -267,7 +270,7 @@ public class BackendService {
         emptySet(),
         null,
         null,
-        null,
+        getSonarLintUserHome().toString(),
         null,
         false,
         new LanguageSpecificRequirements(null, false),

--- a/src/test/java/org/sonarsource/sonarqube/mcp/slcore/BackendServiceTest.java
+++ b/src/test/java/org/sonarsource/sonarqube/mcp/slcore/BackendServiceTest.java
@@ -23,8 +23,10 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.sonarsource.sonarlint.core.rpc.client.ClientJsonRpcLauncher;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcServer;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +56,24 @@ class BackendServiceTest {
     when(mockServer.shutdown()).thenReturn(CompletableFuture.completedFuture(null));
     
     backendService = new BackendService(mockLauncher, tempDir, "1.0", "TestApp");
+  }
+
+  @Test
+  void getWorkDir_should_be_derived_from_storage_path() {
+    assertThat(backendService.getWorkDir()).isEqualTo(tempDir.resolve(".sonarlint").resolve("work"));
+  }
+
+  @Test
+  void initialize_should_pass_storage_path_derived_sonarlint_user_home_and_work_dir() {
+    var analyzers = new BackendService.AnalyzersAndLanguagesEnabled(Set.of(), EnumSet.noneOf(Language.class));
+
+    backendService.initialize(analyzers);
+
+    var captor = ArgumentCaptor.forClass(InitializeParams.class);
+    verify(mockServer).initialize(captor.capture());
+    var params = captor.getValue();
+    assertThat(params.getSonarlintUserHome()).isEqualTo(tempDir.resolve(".sonarlint").toString());
+    assertThat(params.getWorkDir()).isEqualTo(tempDir.resolve(".sonarlint").resolve("work"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Derive SLCORE's `sonarlintUserHome` and `workDir` from `STORAGE_PATH/.sonarlint` instead of `$HOME/.sonarlint`.
- When `HOME` is unset (e.g. some Kubernetes deployments), the JVM resolves `user.home` to `/`, and SLCORE fails to create `/.sonarlint`, leaving the backend service uninitialized for the pod's lifetime. `STORAGE_PATH` is already mandatory and writable, so it's a safe basis for these paths.

## Test plan
- [x] Added unit tests in `BackendServiceTest` asserting `getWorkDir()` and the `InitializeParams` passed to SLCORE derive from `STORAGE_PATH`, not `user.home`.
- [x] `BackendServiceTest` / `BackendServiceTests` pass.
- [x] `AnalyzeCodeSnippetToolTests` (also uses `getWorkDir()`) shows no new failures versus master.

Fixes MCP-604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)